### PR TITLE
Fix recursion error for deep diagrams

### DIFF
--- a/discopy/__init__.py
+++ b/discopy/__init__.py
@@ -46,4 +46,4 @@ from discopy.grammar import cfg, ccg, pregroup
 from discopy.grammar.pregroup import Word
 
 
-__version__ = '0.4.3'
+__version__ = '0.5.0'

--- a/discopy/cartesian.py
+++ b/discopy/cartesian.py
@@ -116,8 +116,9 @@ class Function(rigid.Box):
         >>> assert (copy >> swap)(1) == copy(1)
         >>> assert (swap >> swap)(1, 2) == (1, 2)
         """
+        from discopy.tensor import Tensor
         if len(others) != 1 or any(isinstance(other, Sum) for other in others):
-            return monoidal.Diagram.then(self, *others)
+            return Tensor.then(self, *others)
         other = others[0]
         if not isinstance(other, Function):
             raise TypeError(messages.type_err(Function, other))

--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -285,6 +285,8 @@ class Arrow:
             return self
         if any(isinstance(other, Sum) for other in others):
             return self.sum([self]).then(*others)
+        if any(not isinstance(other, Arrow) for other in others):
+            raise TypeError
         boxes = self.boxes + sum([other.boxes for other in others], [])
         return self.upgrade(Arrow(self.dom, others[-1].cod, boxes))
 

--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -283,17 +283,10 @@ class Arrow:
         """
         if not others:
             return self
-        if len(others) > 1:
-            return self.then(others[0]).then(*others[1:])
-        other, = others
-        if isinstance(other, Sum):
-            return self.sum([self]).then(other)
-        if not isinstance(other, Arrow):
-            raise TypeError(messages.type_err(Arrow, other))
-        if self.cod != other.dom:
-            raise AxiomError(messages.does_not_compose(self, other))
-        return self.upgrade(Arrow(
-            self.dom, other.cod, self.boxes + other.boxes, _scan=False))
+        if any(isinstance(other, Sum) for other in others):
+            return self.sum([self]).then(*others)
+        boxes = self.boxes + sum([other.boxes for other in others], [])
+        return self.upgrade(Arrow(self.dom, others[-1].cod, boxes))
 
     def __rshift__(self, other):
         return self.then(other)

--- a/discopy/matrix.py
+++ b/discopy/matrix.py
@@ -84,9 +84,9 @@ class Matrix(monoidal.Box):
         return repr(self)
 
     def then(self, *others):
-        from discopy import Sum
+        from discopy import Sum, Tensor
         if len(others) != 1 or any(isinstance(other, Sum) for other in others):
-            return monoidal.Diagram.then(self, *others)
+            return Tensor.then(self, *others)
         other, = others
         if not isinstance(other, Matrix):
             raise TypeError(messages.type_err(Matrix, other))

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -411,7 +411,7 @@ class Diagram(cat.Arrow):
         return self._layers
 
     def then(self, *others):
-        if any(isinstance(other, Sum) for other in others):
+        if not others or any(isinstance(other, Sum) for other in others):
             return super().then(*others)
         layers = self.layers.then(*[other.layers for other in others])
         boxes = [box for _, box, _ in layers]

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -411,14 +411,13 @@ class Diagram(cat.Arrow):
         return self._layers
 
     def then(self, *others):
-        if len(others) != 1 or any(isinstance(other, Sum) for other in others):
+        if any(isinstance(other, Sum) for other in others):
             return super().then(*others)
-        other, = others
+        layers = self.layers.then(*[other.layers for other in others])
+        boxes = [box for _, box, _ in layers]
+        offsets = [len(left) for left, _, _ in layers]
         return self.upgrade(
-            Diagram(self.dom, other.cod,
-                    self.boxes + other.boxes,
-                    self.offsets + other.offsets,
-                    layers=self.layers >> other.layers))
+            Diagram(self.dom, others[-1].cod, boxes, offsets, layers))
 
     def tensor(self, other=None, *rest):
         """

--- a/discopy/quantum/cqmap.py
+++ b/discopy/quantum/cqmap.py
@@ -152,7 +152,7 @@ class CQMap(Tensor):
 
     def then(self, *others):
         if len(others) != 1:
-            return monoidal.Diagram.then(self, *others)
+            return Tensor.then(self, *others)
         other, = others
         return CQMap(
             self.dom, other.cod, utensor=self.utensor >> other.utensor)

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -252,7 +252,12 @@ class Tensor(rigid.Box, metaclass=TensorType):
             and Tensor.np.all(Tensor.np.array(self.array == other.array))
 
     def then(self, *others):
-        if len(others) != 1 or any(isinstance(other, Sum) for other in others):
+        if not others:
+            return self
+        if len(others) > 1:
+            head, *tail = others
+            return self.then(head).then(*tail)
+        if any(isinstance(other, Sum) for other in others):
             return monoidal.Diagram.then(self, *others)
         other, = others
         if not isinstance(other, Tensor):


### PR DESCRIPTION
When diagrams get too deep, composition will raise a `RecursionError`.

This PR fixes this by replacing the recursion call of `Arrow.then` by a `for` loop.