### PR TITLE
Fix decompose

### DIFF
--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -369,9 +369,9 @@ class Controlled(QuantumGate):
             return self
         src, tgt = (0, 1) if distance > 0 else (1, 0)
         perm = Circuit.permutation([src, *range(2, n_qubits), tgt])
-        diagram = (perm
+        diagram = (perm[::-1]
                    >> type(self)(controlled) @ Id(abs(distance) - 1)
-                   >> perm[::-1])
+                   >> perm)
         return diagram
 
     def grad(self, var, **params):

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 from unittest.mock import Mock
 from functools import partial
 from pytest import raises
@@ -782,3 +783,23 @@ def test_circuit_chaining():
         Id(1).CRx(0.7, 1, 0)
     with raises(ValueError):
         Id(2).X(999)
+
+
+@pytest.mark.parametrize('x,y', [(0, 1), (0, 2), (1, 0), (2, 0), (5, 0)])
+def test_CX_decompose(x, y):
+    n = abs(x - y) + 1
+    binary_mat = np.eye(n, dtype=int)
+    binary_mat[y] = np.bitwise_xor(binary_mat[x], binary_mat[y])
+
+    N = 1 << n
+    unitary_mat = np.zeros(shape=(N, N))
+    for i in range(N):
+        bits = index2bitstring(i, n)
+        v = bitstring2index(binary_mat @ bits % 2)
+        unitary_mat[i][v] = 1
+
+    # take transpose because tensor axes follow diagrammatic order
+    out = Id(n).CX(x, y).eval().array.reshape(N, N).T
+    # but CX matrices are self transpose
+    assert (out == out.T).all()
+    assert (out == unitary_mat).all()


### PR DESCRIPTION
Resolves the bug that was introduced by #91: by changing the convention of `Diagram.permutation`, we inadvertently broke the decomposition of long ranged gates. Both functor eval and tensor network eval use `_decompose`, this was not picked up by the regression tests. More direct tests have been added.

This bug affects discopy 0.4.3, 0.5.0 and 1.0.0.