### PR TITLE
JSON backward compatibility

### DIFF
--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -809,7 +809,7 @@ class Diagram(cat.Arrow, Whiskerable):
             warn("Outdated dumps", DeprecationWarning)
             boxes, offsets = map(from_tree, tree['boxes']), tree['offsets']
             return cls.decode(from_tree(tree['dom']), zip(boxes, offsets))
-        return cat.Arrow.from_tree.__func__(cls, tree)
+        return super().from_tree(tree)
 
 
 class Box(cat.Box, Diagram):

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import itertools
 from abc import ABC, abstractmethod
 from typing import Iterator
+from warnings import warn
 
 from discopy import cat, drawing, messages
 from discopy.cat import factory, Ob, AxiomError, assert_iscomposable
@@ -191,6 +192,9 @@ class Ty(cat.Ob):
 
     @classmethod
     def from_tree(cls, tree):
+        if not "inside" in tree:
+            warn("Outdated dumps", DeprecationWarning)
+            return cls(*map(from_tree, tree['objects']))
         return cls(*map(from_tree, tree['inside']))
 
     def __matmul__(self, other):
@@ -798,6 +802,14 @@ class Diagram(cat.Arrow, Whiskerable):
                 raise exception
             cache.add(diagram)
         return diagram
+
+    @classmethod
+    def from_tree(cls, tree):
+        if not "inside" in tree:
+            warn("Outdated dumps", DeprecationWarning)
+            boxes, offsets = map(from_tree, tree['boxes']), tree['offsets']
+            return cls.decode(from_tree(tree['dom']), zip(boxes, offsets))
+        return cat.Arrow.from_tree.__func__(cls, tree)
 
 
 class Box(cat.Box, Diagram):

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -192,7 +192,7 @@ class Ty(cat.Ob):
 
     @classmethod
     def from_tree(cls, tree):
-        if not "inside" in tree:
+        if "inside" not in tree:
             warn("Outdated dumps", DeprecationWarning)
             return cls(*map(from_tree, tree['objects']))
         return cls(*map(from_tree, tree['inside']))
@@ -805,7 +805,7 @@ class Diagram(cat.Arrow, Whiskerable):
 
     @classmethod
     def from_tree(cls, tree):
-        if not "inside" in tree:
+        if "inside" not in tree:
             warn("Outdated dumps", DeprecationWarning)
             boxes, offsets = map(from_tree, tree['boxes']), tree['offsets']
             return cls.decode(from_tree(tree['dom']), zip(boxes, offsets))

--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -134,7 +134,7 @@ def from_tree(tree: dict):
     >>> f = Box('f', 'x', 'y', data=42)
     >>> assert from_tree(tree) == f >> f[::-1]
     """
-    *modules, factory = tree['factory'].split('.')
+    *modules, factory = tree['factory'].removeprefix('discopy.').split('.')
     import discopy
     module = discopy
     for attr in modules:

--- a/test/syntax/utils.py
+++ b/test/syntax/utils.py
@@ -5,6 +5,8 @@ from discopy import rigid
 from discopy.cat import Ob
 from discopy.utils import *
 
+from pytest import warns
+
 zip_mock = MagicMock()
 zip_mock.open().__enter__().read.return_value =\
     '[{"factory": "cat.Ob", "name": "a"}]'
@@ -24,4 +26,5 @@ def test_deprecated_from_tree():
         'cod': {'factory': 'discopy.rigid.Ty',
                 'objects': [{'factory': 'discopy.rigid.Ob', 'name': 'n'}]},
         'boxes': [], 'offsets': []}
-    assert from_tree(tree) == rigid.Id(rigid.Ty('n'))
+    with warns(DeprecationWarning):
+        assert from_tree(tree) == rigid.Id(rigid.Ty('n'))

--- a/test/syntax/utils.py
+++ b/test/syntax/utils.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from discopy import rigid
 from discopy.cat import Ob
 from discopy.utils import *
 
@@ -13,3 +14,14 @@ zip_mock.open().__enter__().read.return_value =\
 @patch('zipfile.ZipFile', return_value=zip_mock)
 def test_load_corpus(a, b):
     assert load_corpus("[fake url]") == [Ob("a")]
+
+
+def test_deprecated_from_tree():
+    tree = {
+        'factory': 'discopy.rigid.Diagram',
+        'dom': {'factory': 'discopy.rigid.Ty',
+                'objects': [{'factory': 'discopy.rigid.Ob', 'name': 'n'}]},
+        'cod': {'factory': 'discopy.rigid.Ty',
+                'objects': [{'factory': 'discopy.rigid.Ob', 'name': 'n'}]},
+        'boxes': [], 'offsets': []}
+    assert from_tree(tree) == rigid.Id(rigid.Ty('n'))


### PR DESCRIPTION
This PR allows JSON files created with v0.5 to be imported in v1.0 with a `DeprecationWarning`.