### PR TITLE
Better circuit docs

### DIFF
--- a/discopy/matrix.py
+++ b/discopy/matrix.py
@@ -138,7 +138,7 @@ class Matrix(Composable[int], Whiskerable):
             _cache[dtype] = C
         return _cache[dtype]
 
-    def cast_dtype(self, dtype: type) -> Matrix:
+    def cast(self, dtype: type) -> Matrix:
         """
         Cast a matrix to a given ``dtype``.
 
@@ -147,7 +147,7 @@ class Matrix(Composable[int], Whiskerable):
 
         Example
         -------
-        >>> assert Matrix.id().cast_dtype(bool) == Matrix[bool].id()
+        >>> assert Matrix.id().cast(bool) == Matrix[bool].id()
         """
         return type(self)[dtype](self.array, self.dom, self.cod)
 

--- a/docs/notebooks/qnlp.ipynb
+++ b/docs/notebooks/qnlp.ipynb
@@ -594,7 +594,7 @@
    "source": [
     "vector1 = Tensor[complex]([-1j, 1j], Dim(1), Dim(2)) \n",
     "\n",
-    "vector.cast_dtype(complex) >> vector1.dagger()"
+    "vector.cast(complex) >> vector1.dagger()"
    ]
   },
   {
@@ -1474,7 +1474,7 @@
     "\n",
     "F_(sentence).draw(figsize=(6, 6))\n",
     "\n",
-    "assert F_(sentence).eval().is_close(F(sentence).cast_dtype(complex))"
+    "assert F_(sentence).eval().is_close(F(sentence).cast(complex))"
    ]
   },
   {

--- a/test/quantum/tk.py
+++ b/test/quantum/tk.py
@@ -132,4 +132,4 @@ def test_ClassicalGate_eval():
     backend = tk.mockBackend({
         (0, 0): 256, (0, 1): 256, (1, 0): 256, (1, 1): 256})
     post = ClassicalGate('post', bit ** 2, bit ** 0, [1, 0, 0, 0])
-    assert post.eval(backend=backend) == Tensor[complex]([0.25], Dim(1), Dim(1))
+    assert post.eval(backend=backend) == Tensor[float]([0.25], Dim(1), Dim(1))


### PR DESCRIPTION
Improve the documentation for quantum circuit evaluation.

* `Circuit.eval` now returns `Tensor[float]` when passed a tket backend.
* rename `Matrix.cast_dtype` to `Matrix.cast`