### PR TITLE
Eval with handles

### DIFF
--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -267,7 +267,10 @@ class Circuit(tensor.Diagram):
         """
         from discopy.quantum import cqmap
         if dtype is None:
-            dtype = Dtype.merged(self._infer_dtype(), complex)
+            try:
+                dtype = Dtype.merged(self._infer_dtype(), complex)
+            except:
+                dtype = 'complex64'
         with default_dtype(init_stack=dtype) as dtype:
             if contractor is not None:
                 array = contractor(*self.to_tn(mixed=mixed)).tensor

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -535,7 +535,7 @@ class Rx(AntiConjugate, Rotation):
         with backend() as np, default_dtype(init_stack=self.dtype) as dtype:
             with self.modules() as module:
                 pi = module.pi()
-            half_theta = np.copy(np.asarray(pi * self.phase.detach().numpy(), dtype=dtype.like_backend(np)))
+            half_theta = np.copy(np.asarray(pi * self.phase.cpu().detach().numpy(), dtype=dtype.like_backend(np)))
             with self.modules() as module:
                 sin, cos = module.sin(half_theta), module.cos(half_theta)
             return np.stack((cos, -1j * sin, -1j * sin, cos)).reshape(2, 2)

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -535,7 +535,7 @@ class Rx(AntiConjugate, Rotation):
         with backend() as np, default_dtype(init_stack=self.dtype) as dtype:
             with self.modules() as module:
                 pi = module.pi()
-            half_theta = np.copy(np.asarray(pi * self.phase, dtype=dtype.like_backend(np)))
+            half_theta = np.copy(np.asarray(pi * self.phase.detach().numpy(), dtype=dtype.like_backend(np)))
             with self.modules() as module:
                 sin, cos = module.sin(half_theta), module.cos(half_theta)
             return np.stack((cos, -1j * sin, -1j * sin, cos)).reshape(2, 2)

--- a/discopy/quantum/tk.py
+++ b/discopy/quantum/tk.py
@@ -192,7 +192,13 @@ class Circuit(tk.Circuit):
         assert (backend is not None) ^ (experiment is not None), "Either backend or experiment must be provided."
         
         if experiment is not None:
-            counts = [experiment.get_result(h).get_counts() for h in handles]
+            counts = []
+            for h in handles:
+                print(h)
+                process_job = experiment.get_process_job(handle=h)
+                print(process_job)
+                counts.append(experiment.get_result(h).get_counts())
+            # counts = [experiment.get_result(h).get_counts() for h in handles]
         else:
             counts = [backend.get_result(h, timeout=None).get_counts() for h in handles]
         


### PR DESCRIPTION
Discopy's `.eval()` runs one circuit at a time -- you get a handle, then you wait, then you get a result back. This is inefficient for running on real backends, especially ones that support batching, and risks timing out. This pull request adds `.eval_get_handles()` and `.eval_from_handles()` to circuit.py and `get_handles()` and `get_counts_from_handles()` from tk.py. This means you can submit a load of circuits in one go, store the handles, then retrieve them later.