### PR TITLE
Increase precision of eval tests to 1.e-15, legacy branch

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: [ 3.8, 3.9, "3.10" ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install linter
@@ -32,9 +32,9 @@ jobs:
       matrix:
         python-version: [ 3.8, 3.9, "3.10" ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install base package

--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -486,8 +486,8 @@ class Circuit(tensor.Diagram):
                         q_scan2[q_offset + 1], q_scan2[q_offset]
                     continue
                 utensor = box.array
-                node1 = tn.Node(Tensor.np.conj(utensor) + 0j, 'q1_' + str(box))
-                node2 = tn.Node(utensor + 0j, 'q2_' + str(box))
+                node1 = tn.Node(utensor + 0j, 'q1_' + str(box))
+                node2 = tn.Node(Tensor.np.conj(utensor) + 0j, 'q2_' + str(box))
 
                 for i in range(len(box.dom)):
                     tn.connect(q_scan1[q_offset + i], node1[i])

--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -486,8 +486,8 @@ class Circuit(tensor.Diagram):
                         q_scan2[q_offset + 1], q_scan2[q_offset]
                     continue
                 utensor = box.array
-                node1 = tn.Node(utensor + 0j, 'q1_' + str(box))
-                node2 = tn.Node(Tensor.np.conj(utensor) + 0j, 'q2_' + str(box))
+                node1 = tn.Node(Tensor.np.conj(utensor) + 0j, 'q1_' + str(box))
+                node2 = tn.Node(utensor + 0j, 'q2_' + str(box))
 
                 for i in range(len(box.dom)):
                     tn.connect(q_scan1[q_offset + i], node1[i])

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -37,7 +37,8 @@ contractor = tn.contractors.auto
 
 @pytest.mark.parametrize('c', pure_circuits + mixed_circuits)
 def test_mixed_eval(c):
-    assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
+    assert np.allclose(c.eval(contractor=contractor), c.eval(),
+                       rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
@@ -53,13 +54,15 @@ def test_consistent_eval(c):
 @pytest.mark.parametrize('c', mixed_circuits)
 def test_pytorch_mixed_eval(c):
     with tn.DefaultBackend('pytorch'):
-        assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
+        assert np.allclose(c.eval(contractor=contractor), c.eval(),
+                           rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
 def test_pytorch_pure_eval(c):
     with tn.DefaultBackend('pytorch'):
-        assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
+        assert np.allclose(c.eval(contractor=contractor), c.eval(),
+                           rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
@@ -71,4 +74,5 @@ def test_pytorch_consistent_eval(c):
         doubled_result = (
             pure_result
             @ pure_result.conjugate(diagrammatic=False))
-        assert np.allclose(doubled_result, mixed_result, rtol=1.e-15, atol=1.e-15)
+        assert np.allclose(doubled_result, mixed_result,
+                           rtol=1.e-15, atol=1.e-15)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -72,7 +72,8 @@ def test_pytorch_consistent_eval(c):
         mixed_result = c.eval(mixed=True, contractor=contractor)
 
         doubled_result = (
-            pure_result
-            @ pure_result.conjugate(diagrammatic=False))
+            pure_result.conjugate(diagrammatic=False)
+            @ pure_result
+        )
         assert np.allclose(doubled_result, mixed_result,
                            rtol=1.e-15, atol=1.e-15)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -71,9 +71,7 @@ def test_pytorch_consistent_eval(c):
         pure_result = c.eval(mixed=False, contractor=contractor)
         mixed_result = c.eval(mixed=True, contractor=contractor)
 
-        doubled_result = (
-            pure_result.conjugate(diagrammatic=False)
-            @ pure_result
-        )
+        doubled_result = (pure_result
+                          @ pure_result.conjugate(diagrammatic=False))
         assert np.allclose(doubled_result, mixed_result,
                            rtol=1.e-15, atol=1.e-15)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -71,7 +71,8 @@ def test_pytorch_consistent_eval(c):
         pure_result = c.eval(mixed=False, contractor=contractor)
         mixed_result = c.eval(mixed=True, contractor=contractor)
 
-        doubled_result = (pure_result
-                          @ pure_result.conjugate(diagrammatic=False))
+        doubled_result = (
+            pure_result
+            @ pure_result.conjugate(diagrammatic=False))
         assert np.allclose(doubled_result, mixed_result,
                            rtol=1.e-15, atol=1.e-15)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -37,7 +37,7 @@ contractor = tn.contractors.auto
 
 @pytest.mark.parametrize('c', pure_circuits + mixed_circuits)
 def test_mixed_eval(c):
-    assert np.allclose(c.eval(contractor=contractor), c.eval())
+    assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
@@ -47,19 +47,19 @@ def test_consistent_eval(c):
 
     doubled_result = (pure_result
                       @ pure_result.conjugate(diagrammatic=False))
-    np.allclose(doubled_result, mixed_result)
+    np.allclose(doubled_result, mixed_result, rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', mixed_circuits)
 def test_pytorch_mixed_eval(c):
     with tn.DefaultBackend('pytorch'):
-        assert np.allclose(c.eval(contractor=contractor), c.eval())
+        assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
 def test_pytorch_pure_eval(c):
     with tn.DefaultBackend('pytorch'):
-        assert np.allclose(c.eval(contractor=contractor), c.eval())
+        assert np.allclose(c.eval(contractor=contractor), c.eval(), rtol=1.e-15, atol=1.e-15)
 
 
 @pytest.mark.parametrize('c', pure_circuits)
@@ -71,4 +71,4 @@ def test_pytorch_consistent_eval(c):
         doubled_result = (
             pure_result
             @ pure_result.conjugate(diagrammatic=False))
-        np.allclose(doubled_result, mixed_result)
+        assert np.allclose(doubled_result, mixed_result, rtol=1.e-15, atol=1.e-15)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -46,8 +46,8 @@ def test_consistent_eval(c):
     pure_result = c.eval(mixed=False, contractor=contractor)
     mixed_result = c.eval(mixed=True, contractor=contractor)
 
-    doubled_result = (pure_result
-                      @ pure_result.conjugate(diagrammatic=False))
+    doubled_result = (pure_result.conjugate(diagrammatic=False)
+                      @ pure_result)
     np.allclose(doubled_result, mixed_result, rtol=1.e-15, atol=1.e-15)
 
 
@@ -72,7 +72,7 @@ def test_pytorch_consistent_eval(c):
         mixed_result = c.eval(mixed=True, contractor=contractor)
 
         doubled_result = (
-            pure_result
-            @ pure_result.conjugate(diagrammatic=False))
+            pure_result.conjugate(diagrammatic=False)
+            @ pure_result)
         assert np.allclose(doubled_result, mixed_result,
                            rtol=1.e-15, atol=1.e-15)


### PR DESCRIPTION
The last test in eval, `pytorch_consitent_eval` now fails. It fails even with a tolerance of 1.e-6.