### PR TITLE
Change the way the lxml is imported

### DIFF
--- a/discopy/drawing/grid.py
+++ b/discopy/drawing/grid.py
@@ -19,12 +19,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-try:
-    from lxml.etree import SubElement, ElementTree
-    from lxml.html import Element
-except ImportError:
-    pass
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    import lxml
 
 TABLE_STYLE = ".diagram .wire { border-left: 4px solid; text-align: left; } "\
               ".diagram .box { border: 4px solid; text-align: center; }"\
@@ -58,6 +56,7 @@ class Cell:
 
 class Wire(Cell):
     """ A wire is a cell with ``stop = start``. """
+
     def __init__(self, start: int, label: discopy.monoidal.Ty = None):
         super().__init__(start, start, label)
 
@@ -105,6 +104,11 @@ class Grid:
     def to_html(self) -> lxml.etree.ElementTree:
         """
         Turn a grid into an html table.
+
+        Notes
+        -----
+        This function requires the `lxml` package to be installed in addition
+        to the default requirements.
 
         Examples
         --------
@@ -165,6 +169,8 @@ class Grid:
             <iframe src="../_static/drawing/example.html"
             class="diagram-frame" height="500"></iframe>
         """
+        from lxml.etree import SubElement, ElementTree
+        from lxml.html import Element
         root = Element("div")
         style = SubElement(root, "style")
         style.text = TABLE_STYLE
@@ -261,6 +267,7 @@ class Grid:
                     result += space + str(
                         cell.label.name)[:width].center(width, box_chr)
             return result
+
         return '\n'.join(map(row_to_ascii, self.rows)).strip('\n')
 
     @staticmethod
@@ -287,6 +294,7 @@ class Grid:
              [Cell(0, 4, f), Cell(6, 8, s), Cell(10, 16, f[::-1])],
              [Wire(1, x), Wire(3, x), Wire(11, x)])
         """
+
         def make_boxes_as_small_as_possible(
                 rows: list[list[Cell]]) -> list[list[Cell]]:
             for top, middle, bottom in zip(rows, rows[1:], rows[2:]):
@@ -326,6 +334,7 @@ class Grid:
                     for j, cell in enumerate(row):
                         cell.start += space * int(cell.start >= limit)
                         cell.stop += space * int(cell.stop >= limit)
+
         rows = [[Wire(2 * i + 1, x) for i, x in enumerate(diagram.dom)]]
         for layer in diagram.inside:
             offset = 0


### PR DESCRIPTION
The package lxml is only required for a specific drawing function, Grid.to_html in grid.py. Because of this, lxml is not listed in requirements.txt, and it has been imported inside a try-except block. However, this results in very poor error messages:
```
NameError: name 'Element' is not defined
```

This commit places the lxml import inside the function where it is required so that we have a better error message:
```
ModuleNotFoundError: No module named 'lxml'
```
Also, a note has been added to the docstring of the function where it is imported.