### PR TITLE
Fix jax support

### DIFF
--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -503,8 +503,6 @@ class Box(Arrow):
     """
     def __init__(self, name, dom, cod, **params):
         def recursive_free_symbols(data):
-            if hasattr(data, 'tolist'):
-                data = data.tolist()
             if isinstance(data, Mapping):
                 data = data.values()
             if isinstance(data, Iterable):

--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -24,6 +24,8 @@ We can create dagger functors from the free category to itself:
 from functools import total_ordering
 from collections.abc import Mapping, Iterable
 
+import numpy as np
+
 from discopy import messages
 from discopy.utils import factory_name, from_tree, rsubs, rmap
 
@@ -503,6 +505,8 @@ class Box(Arrow):
     """
     def __init__(self, name, dom, cod, **params):
         def recursive_free_symbols(data):
+            if isinstance(data, np.ndarray):
+                data = data.tolist()
             if isinstance(data, Mapping):
                 data = data.values()
             if isinstance(data, Iterable):


### PR DESCRIPTION
the `.tolist` method triggers a `ConcretizationTypeError` when using jax traced objects as `data`. In discopy 1.~. these two lines are removed.