### PR TITLE
Legacy: Fix serialisation

### DIFF
--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -252,6 +252,10 @@ class PRO(Ty):
             n = n.name
         super().__init__(*(n * [1]))
 
+    @classmethod
+    def from_tree(cls, tree):
+        return cls(len(tree["objects"]))
+
     def __repr__(self):
         return "PRO({})".format(len(self))
 

--- a/discopy/quantum/zx.py
+++ b/discopy/quantum/zx.py
@@ -4,6 +4,7 @@
 
 from discopy import messages, cat, monoidal, rigid, quantum, tensor
 from discopy.monoidal import Sum
+from discopy.utils import from_tree
 from discopy.rigid import Functor, PRO
 from discopy.quantum.circuit import Circuit, qubit
 from discopy.quantum.gates import (
@@ -267,6 +268,12 @@ class Spider(Box):
         self.draw_as_spider, self.drawing_name = True, phase or ""
         self.tikzstyle_name = name
 
+    @classmethod
+    def from_tree(cls, tree):
+        n_legs_in = len(from_tree(tree["dom"]))
+        n_legs_out = len(from_tree(tree["cod"]))
+        return cls(n_legs_in, n_legs_out, tree["data"])
+
     @property
     def name(self):
         return "{}({}, {}{})".format(
@@ -366,6 +373,10 @@ class Had(Box):
         self.drawing_name, self.tikzstyle_name, = '', 'H'
         self.color, self.shape = "yellow", "rectangle"
 
+    @classmethod
+    def from_tree(cls, _):
+        return cls()
+
     def __repr__(self):
         return self.name
 
@@ -381,6 +392,10 @@ class Scalar(Box):
     def __init__(self, data):
         super().__init__("scalar", PRO(0), PRO(0), data=data)
         self.drawing_name = format_number(data)
+
+    @classmethod
+    def from_tree(cls, tree):
+        return cls(tree["data"])
 
     @property
     def name(self):

--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -54,7 +54,13 @@ def dumps(obj):
         'dom': {'factory': 'discopy.cat.Ob', 'name': 'x'},
         'factory': 'discopy.cat.Arrow'}
     """
-    return json.dumps(obj.to_tree())
+    try:
+        return json.dumps(obj.to_tree())
+    except TypeError:
+        raise TypeError(
+            "The given object cannot be serialised using JSON."
+            "Consider using `pickle.dumps` instead."
+        )
 
 
 def loads(raw):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,13 +4,12 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from discopy import Ob
-from discopy.quantum.gates import Rx
+from discopy.quantum.gates import Rx, Z, H, CZ
 from discopy.quantum.zx import H as HBox, Z as ZSpider, scalar
 from discopy.utils import *
 
-gates = [
-    Rx(1), HBox, ZSpider(2, 4), scalar(1),
-]
+gates = [Rx(1), HBox, ZSpider(2, 4), scalar(1)]
+extra_gates = [CZ, H, Z]
 
 zip_mock = MagicMock()
 zip_mock.open().__enter__().read.return_value =\
@@ -23,6 +22,17 @@ def test_load_corpus(a, b):
     assert load_corpus("[fake url]") == [Ob("a")]
 
 
+@pytest.mark.parametrize('c', gates + extra_gates)
+def test_to_and_from_tree(c):
+    assert c == from_tree(c.to_tree())
+
+
 @pytest.mark.parametrize('c', gates)
-def test_pickled_gate_serialisation(c):
+def test_gate_serialisation(c):
     assert c == loads(dumps(c))
+
+
+def test_gate_serialisation_error():
+    from sympy import Symbol
+    with pytest.raises(TypeError):
+        dumps(Rx(Symbol('alpha')))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,16 @@
+import pytest
+
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from discopy import Ob
+from discopy.quantum.gates import Rx
+from discopy.quantum.zx import H as HBox, Z as ZSpider, scalar
 from discopy.utils import *
 
+gates = [
+    Rx(1), HBox, ZSpider(2, 4), scalar(1),
+]
 
 zip_mock = MagicMock()
 zip_mock.open().__enter__().read.return_value =\
@@ -14,3 +21,8 @@ zip_mock.open().__enter__().read.return_value =\
 @patch('zipfile.ZipFile', return_value=zip_mock)
 def test_load_corpus(a, b):
     assert load_corpus("[fake url]") == [Ob("a")]
+
+
+@pytest.mark.parametrize('c', gates)
+def test_pickled_gate_serialisation(c):
+    assert c == loads(dumps(c))


### PR DESCRIPTION
Fix `to_tree` and `from_tree` whenever necessary.

Raise error when an object cannot be dumped using `JSON.dumps` in `utils.dumps`.

Add new tests.

Closes #185