### PR TITLE
Implement circuit serialisation

### DIFF
--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -103,6 +103,14 @@ class Ob(frobenius.Ob):
     def __repr__(self):
         return f"{factory_name(type(self))}({self.dim})"
 
+    @classmethod
+    def from_tree(cls, tree: dict) -> Ob:
+        dim, z = tree['dim'], tree.get('z', 0)
+        return cls(dim=dim, z=z)
+
+    def to_tree(self) -> dict:
+        return dict(dim=self.dim, **super().to_tree())
+
 
 class Digit(Ob):
     """

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -570,6 +570,10 @@ class Rotation(Parametrized, QuantumGate):
         QuantumGate.__init__(self, name, dom, cod, z=z)
         Parametrized.__init__(self, name, dom, cod, is_mixed=False, data=phase)
 
+    @classmethod
+    def from_tree(cls, tree: dict):
+        return cls(tree['data'], tree.get('z', 0))
+
     @property
     def phase(self):
         """ The phase of a rotation gate. """

--- a/test/quantum/circuit.py
+++ b/test/quantum/circuit.py
@@ -762,3 +762,8 @@ def test_pennylane_gradient_methods():
         loss = p_var_circ.eval().norm(dim=0, p=2)
         loss.backward()
         assert weights[0].grad is not None
+
+
+def test_loads_dumps():
+    from discopy.utils import loads, dumps
+    assert loads(dumps(Rx(1))) == Rx(1)


### PR DESCRIPTION
Up till now, circuits could not be serialised because `Ob` and `Rotation` gates use custom init signatures.