### PR TITLE
Update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 DisCoPy is a Python toolkit for computing with [string diagrams](https://en.wikipedia.org/wiki/String_diagram).
 
-* **Organisation:** https://discopy.org
-* **Documentation:** https://docs.discopy.org
-* **Source code:** https://github.com/discopy/discopy
-* **Paper (for applied category theorists):** https://doi.org/10.4204/EPTCS.333.13
-* **Paper (for quantum computer scientists):** https://arxiv.org/abs/2205.05190
+* **Organisation:** <https://discopy.org>
+* **Documentation:** <https://docs.discopy.org>
+* **Source code:** <https://github.com/discopy/discopy>
+* **Paper (for applied category theorists):** <https://doi.org/10.4204/EPTCS.333.13>
+* **Paper (for quantum computer scientists):** <https://arxiv.org/abs/2205.05190>
 
 DisCoPy began as an implementation of [DisCoCat](https://en.wikipedia.org/wiki/DisCoCat) and [QNLP](https://en.wikipedia.org/wiki/Quantum_natural_language_processing). This has now become its own library: [lambeq](https://cqcl.github.io/lambeq).
 

--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -21,7 +21,6 @@ Summary
     Category
     Functor
     Composable
-    AxiomError
 
 .. admonition:: Functions
 

--- a/discopy/matrix.py
+++ b/discopy/matrix.py
@@ -30,9 +30,8 @@ Summary
 See also
 --------
 
-* :class:`Tensor` is a subclass of :class:`Matrix` with the Kronecker product
-  as tensor.
-* :class:`Matrix` is used to evaluate :class:`quantum.optics.Diagram`.
+* :class:`discopy.tensor.Tensor` is a subclass of :class:`Matrix` with the
+  Kronecker product as tensor.
 
 """
 from __future__ import annotations
@@ -182,26 +181,27 @@ class Matrix(Composable[int], Whiskerable, NamedGeneric['dtype']):
             and (self.dom, self.cod) == (other.dom, other.cod)\
             and (self.array == other.array).all()
 
-    def is_close(self, other: Matrix, rtol=1.e-8, atol=1.e-8) -> bool:
+    def is_close(self, other: Matrix, rtol: float = 1.e-8, atol: float = 1.e-8
+                 ) -> bool:
         """
         Whether a matrix is numerically close to an ``other``.
 
         Parameters:
             other : The other matrix with which to check closeness.
-            rtol: float
-                    The relative tolerance parameter (see Notes).
-                    Default value for results of order unity is 1.e-5
-            atol : float
-                    The absolute tolerance parameter (see Notes).
-                    Default value for results of order unity is 1.e-8
+            rtol:
+                The relative tolerance parameter (see Notes).
+                Default value for results of order unity is 1.e-5
+            atol :
+                The absolute tolerance parameter (see Notes).
+                Default value for results of order unity is 1.e-8
 
         Notes:
-       (taken from np.isclose documentation)
+        (taken from np.isclose documentation)
 
             For finite values, isclose uses the following equation to
             test whether two floating point values are equivalent.
 
-             absolute(`a` - `b`) <= (`atol` + `rtol` * absolute(`b`))
+            absolute(`a` - `b`) <= (`atol` + `rtol` * absolute(`b`))
 
             Unlike the built-in `math.isclose`, the above equation is not
             symmetric in `a` and `b` -- it assumes `b` is the reference

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -32,6 +32,8 @@ Summary
     Ry
     Rz
     CU1
+    CRz
+    CRx
     Scalar
     MixedScalar
     Sqrt
@@ -43,8 +45,6 @@ Summary
         :nosignatures:
         :toctree:
 
-        CRz
-        CRx
         sqrt
         scalar
 """

--- a/discopy/traced.py
+++ b/discopy/traced.py
@@ -34,6 +34,7 @@ Axioms
 >>> f, g = Box('f', x @ x, x @ x), Box('g', x, x)
 
 * Vanishing
+
 >>> assert f.trace(n=0) == f == f.trace(n=0, left=True)
 >>> assert f.trace(n=2) == f.trace().trace()
 >>> assert f.trace(n=2, left=True) == f.trace(left=True).trace(left=True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
-              'm2r2',
+              'myst_parser',
               'sphinx.ext.mathjax',
               'youtube',
               'bases-fullname',
@@ -90,7 +90,14 @@ html_theme_options = {
     "repository_url": "https://github.com/discopy/discopy",
     "use_repository_button": True,
     "path_to_docs": "docs",
-    "extra_navbar": "",
+    # "extra_navbar": "",
+}
+myst_enable_extensions = ["attrs_block"]
+myst_url_schemes = {
+    "http": None,
+    "https": None,
+    "doi": "https://doi.org/{{path}}",
+    "arXiv": "https://arxiv.org/abs/{{path}}",
 }
 
 master_doc = 'index'

--- a/docs/extra/blogs.md
+++ b/docs/extra/blogs.md
@@ -13,16 +13,16 @@ These two blog posts introduce QNLP with DisCoPy and [lambeq](https://github.com
 
 This blog by [Pawel Sobocinski](https://www.ioc.ee/~pawel/) is what got us hooked to string diagrams.
 
-* https://graphicallinearalgebra.net/
+* <https://graphicallinearalgebra.net>
 
 ## Monads and comonads
 
 Dan Marsden writing about applications of string diagrams to monads, comonads and theoretical computer science.
 
-* https://stringdiagram.com/
+* <https://stringdiagram.com>
 
 ## Azimuth
 
 [John Baez](https://math.ucr.edu/home/baez/)'s blog is a great place to learn about string diagrams and category theory.
 
-* https://johncarlosbaez.wordpress.com/?s=string+diagram
+* <https://johncarlosbaez.wordpress.com/?s=string+diagram>

--- a/docs/extra/papers.md
+++ b/docs/extra/papers.md
@@ -4,7 +4,7 @@
 
 ### Category Theory for Quantum Natural Language Processing
 
-https://arxiv.org/abs/2212.06615
+<arXiv:2212.06615>
 
 Alexis Toumi
 
@@ -17,7 +17,7 @@ The second chapter uses DisCopy to implement QNLP models as parameterised functo
 
 ### Categorical Tools for Natural Language Processing
 
-https://arxiv.org/abs/2212.06636
+<arXiv:2212.06636>
 
 Giovanni de Felice
 
@@ -28,7 +28,7 @@ This thesis develops the translation between category theory and computational l
 
 ### DisCoPy: Monoidal categories in Python
 
-https://doi.org/10.4204/EPTCS.333.13
+<doi:10.4204/EPTCS.333.13>
 
 Giovanni de Felice, Alexis Toumi, Bob Coecke
 
@@ -37,7 +37,7 @@ We introduce DisCoPy, an open source toolbox for computing with monoidal categor
 
 ### Diagrammatic Differentiation for Quantum Machine Learning
 
-https://doi.org/10.4204/EPTCS.343.7
+<doi:10.4204/EPTCS.343.7>
 
 Alexis Toumi, Richie Yeung, Giovanni de Felice
 
@@ -46,7 +46,7 @@ We introduce diagrammatic differentiation for tensor calculus by generalising th
 
 ### DisCoPy for the quantum computer scientist
 
-https://arxiv.org/abs/2205.05190
+<arXiv:2205.05190>
 
 Alexis Toumi, Giovanni de Felice, Richie Yeung
 
@@ -55,7 +55,7 @@ DisCoPy (Distributional Compositional Python) is an open source toolbox for comp
 
 ### Functorial Language Models
 
-https://arxiv.org/abs/2103.14411
+<arXiv:2103.14411>
 
 Alexis Toumi, Alex Koziell-Pipe
 

--- a/docs/extra/talks.rst
+++ b/docs/extra/talks.rst
@@ -41,17 +41,17 @@ The first demo of DisCoPy experiments on quantum hardware was presented at
 
 .. youtube:: NJFYXZyeMj0
 
-.. _qnlp-experiment: https://github.com/discopy/discopy/blob/main/docs/notebooks/qnlp-experiment.ipynb
+.. _qnlp-experiment: https://github.com/discopy/discopy/blob/legacy/docs/notebooks/qnlp-experiment.ipynb
 .. _QNLP 2020: https://quantumweek2020.cambridgequantum.com/qnlp.html
 
 QNLP 2019
 ---------
 
 The first demo of DisCoPy was presented at
-`the first QNLP workshop <http://www.cs.ox.ac.uk/QNLP2019/>`_
+`the first QNLP workshop <http://www.cs.ox.ac.uk/QNLP2019>`_
 see the corresponding notebooks alice-loves-bob_ and bob-is-rich_.
 
 .. youtube:: 3UKqpL7Z0Uc
 
-.. _alice-loves-bob: https://github.com/discopy/discopy/blob/main/notebooks/alice-loves-bob.ipynb
-.. _bob-is-rich: https://github.com/discopy/discopy/blob/main/notebooks/bob-is-rich.ipynb
+.. _alice-loves-bob: https://github.com/discopy/discopy/blob/legacy/docs/notebooks/alice-loves-bob.ipynb
+.. _bob-is-rich: https://github.com/discopy/discopy/blob/legacy/docs/notebooks/bob-is-rich.ipynb

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,15 +4,17 @@
 DisCoPy documentation
 #####################
 
-.. mdinclude:: ../README.md
+.. include:: ../README.md
+    :parser: myst_parser.sphinx_
     :start-line: 10
     :end-line: 37
 
 .. raw:: html
-   :file: api/architecture.html
+    :file: api/architecture.html
 
-.. mdinclude:: ../README.md
-   :start-line: 39
+.. include:: ../README.md
+    :parser: myst_parser.sphinx_
+    :start-line: 39
 
 .. toctree::
     :caption: Reference API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,14 +57,14 @@ test = [
     "pylint"
 ]
 docs  = [
-    "sphinx == 4.5.0",
-    "sphinx-book-theme == 0.3.3",
-    "m2r2 == 0.3.2",
-    "nbsphinx == 0.8.9",
-    "ipykernel == 6.17.0",
-    "sphinxcontrib-youtube == 1.2.0",
-    "jinja2 == 3.0.3",
-    "sphinxcontrib-bibtex == 2.4.0",
+    "sphinx == 6.0.*",
+    "sphinx-book-theme == 1.0.*",
+    "myst-parser == 2.0.*",
+    "nbsphinx == 0.9.*",
+    "ipykernel == 6.23.*",
+    "sphinxcontrib-youtube == 1.2.*",
+    "jinja2 == 3.1.*",
+    "sphinxcontrib-bibtex == 2.5.*",
     "IPython"
 ]
 


### PR DESCRIPTION
The dependencies have been updated as `m2r2` has a dependency that just wouldn't work with a moder setup.

In newer versions of `sphinx`, it is possible to simply include markdown files given that `myst-parser` is included as an extension.

Some warnings of sphynx have been resolved, but there's still a lot to clean up.

Broken links have been fixed.