### PR TITLE
Legacy fix recursion

### DIFF
--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -247,6 +247,7 @@ class Arrow:
     def __radd__(self, other):
         return self + other
 
+    # @unbiased
     def then(self, *others):
         """
         Returns the composition of `self` with arrows `others`.
@@ -259,8 +260,8 @@ class Arrow:
 
         Parameters
         ----------
-        others : cat.Arrow
-            such that `self.cod == others[0].dom`
+        other : cat.Arrow
+            such that `self.cod == other.dom`
             and `all(x.cod == y.dom for x, y in zip(others, others[1:])`.
 
         Returns
@@ -295,6 +296,14 @@ class Arrow:
                 raise AxiomError(messages.does_not_compose(x, y))
         boxes = self.boxes + sum([other.boxes for other in others], [])
         return self.upgrade(Arrow(self.dom, others[-1].cod, boxes))
+        # if isinstance(other, Sum):
+        #     return self.sum([self]).then(other)
+        # if not isinstance(other, Arrow):
+        #     raise TypeError(messages.type_err(Arrow, other))
+        # if self.cod != other.dom:
+        #     raise AxiomError(messages.does_not_compose(self, other))
+        # boxes = self.boxes + other.boxes
+        # return self.upgrade(Arrow(self.dom, other.cod, boxes))
 
     def __rshift__(self, other):
         return self.then(other)

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -41,7 +41,7 @@ We can check the Eckmann-Hilton argument, up to interchanger.
 from discopy import cat, messages, drawing, rewriting
 from discopy.cat import Ob
 from discopy.messages import WarnOnce
-from discopy.utils import factory_name, from_tree
+from discopy.utils import factory_name, from_tree, unbiased
 
 warn_permutation = WarnOnce()
 
@@ -410,14 +410,15 @@ class Diagram(cat.Arrow):
         """
         return self._layers
 
-    def then(self, *others):
-        if not others or any(isinstance(other, Sum) for other in others):
-            return super().then(*others)
-        layers = self.layers.then(*[other.layers for other in others])
+    @unbiased
+    def then(self, other):
+        if isinstance(other, Sum):
+            return super().then(other)
+        layers = self.layers.then(other.layers)
         boxes = [box for _, box, _ in layers]
         offsets = [len(left) for left, _, _ in layers]
         return self.upgrade(
-            Diagram(self.dom, others[-1].cod, boxes, offsets, layers))
+            Diagram(self.dom, other.cod, boxes, offsets, layers))
 
     def tensor(self, other=None, *rest):
         """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. image:: /_static/snake-equation.png
+.. image:: /_static/imgs/snake-equation.png
 
 #####################
 DisCoPy documentation


### PR DESCRIPTION
Both `cat.Arrow` and `monoidal.Diagram` have been implemented using as a more efficient `@unbiased` method.

A cheeky fix in the documentation