### PR TITLE
Fix PennyLane Sympy substitution

### DIFF
--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -78,6 +78,7 @@ def tk_op_to_pennylane(tk_op):
     """
     wires = [x.index[0] for x in tk_op.qubits]
     params = tk_op.op.params
+    symbols = set()
 
     remapped_params = []
     for param in params:
@@ -85,10 +86,12 @@ def tk_op_to_pennylane(tk_op):
         param /= 2
         if not isinstance(param, sympy.Expr):
             param = torch.tensor(param)
+        else:
+            symbols.update(param.free_symbols)
 
         remapped_params.append(param)
 
-    return OP_MAP[tk_op.op.type], remapped_params, wires
+    return OP_MAP[tk_op.op.type], remapped_params, symbols, wires
 
 
 def extract_ops_from_tk(tk_circ):
@@ -115,15 +118,17 @@ def extract_ops_from_tk(tk_circ):
         The corresponding wires of the operations.
     """
     op_list, params_list, wires_list = [], [], []
+    symbols_set = set()
 
     for op in tk_circ.__iter__():
         if op.op.type != OpType.Measure:
-            op, params, wires = tk_op_to_pennylane(op)
+            op, params, symbols, wires = tk_op_to_pennylane(op)
             op_list.append(op)
             params_list.append(params)
             wires_list.append(wires)
+            symbols_set.update(symbols)
 
-    return op_list, params_list, wires_list
+    return op_list, params_list, wires_list, symbols_set
 
 
 def get_post_selection_dict(tk_circ):
@@ -174,7 +179,8 @@ def to_pennylane(disco_circuit: Circuit, probabilities=False,
                          'supported.')
 
     tk_circ = disco_circuit.to_tk()
-    op_list, params_list, wires_list = extract_ops_from_tk(tk_circ)
+    op_list, params_list, wires_list, symbols_set = \
+        extract_ops_from_tk(tk_circ)
 
     post_selection = get_post_selection_dict(tk_circ)
 
@@ -184,6 +190,7 @@ def to_pennylane(disco_circuit: Circuit, probabilities=False,
             scalar *= box.array
 
     return PennyLaneCircuit(op_list,
+                            list(symbols_set),
                             params_list,
                             wires_list,
                             probabilities,
@@ -202,10 +209,11 @@ class PennyLaneCircuit:
     """
     Implement a pennylane circuit with post-selection.
     """
-    def __init__(self, ops, params, wires, probabilities,
+    def __init__(self, ops, symbols, params, wires, probabilities,
                  post_selection, scale, n_qubits, backend_config,
                  diff_method):
         self._ops = ops
+        self._symbols = symbols
         self._params = params
         self._wires = wires
         self._probabilities = probabilities
@@ -277,14 +285,15 @@ class PennyLaneCircuit:
         return any(isinstance(expr, sympy.Expr) for expr_list in
                    self._params for expr in expr_list)
 
-    def initialise_concrete_params(self, symbols, weights):
+    def initialise_concrete_params(self, symbol_weight_map):
         """
         Given concrete values for each of the SymPy symbols, substitute
         the symbols for the values to obtain concrete parameters, via
         the `param_substitution` method.
         """
         if self._contains_sympy:
-            self._concrete_params = self.param_substitution(symbols, weights)
+            weights = [symbol_weight_map[symbol] for symbol in self._symbols]
+            self._concrete_params = self.param_substitution(weights)
 
     def draw(self):
         """
@@ -383,7 +392,7 @@ class PennyLaneCircuit:
         else:
             return torch.reshape(post_selected_states, (2,) * open_wires)
 
-    def param_substitution(self, symbols, weights):
+    def param_substitution(self, weights):
         """
         Substitute symbolic parameters (SymPy symbols) with floats.
 
@@ -405,7 +414,7 @@ class PennyLaneCircuit:
             concrete_list = []
             for expr in expr_list:
                 if isinstance(expr, sympy.Expr):
-                    f_expr = sympy.lambdify([symbols], expr)
+                    f_expr = sympy.lambdify([self._symbols], expr)
                     expr = f_expr(weights)
                 concrete_list.append(expr)
             concrete_params.append(concrete_list)

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -73,6 +73,8 @@ def tk_op_to_pennylane(tk_op):
         The PennyLane operation equivalent to the input pytket Op.
     list of (:class:`torch.FloatTensor` or :class:`sympy.core.symbol.Symbol`)
         The parameters of the operation.
+    list of :class:`sympy.core.symbol.Symbol`
+        The free symbols in the parameters of the operation.
     list of int
         The wires/qubits to apply the operation to.
     """
@@ -116,6 +118,8 @@ def extract_ops_from_tk(tk_circ):
         The corresponding parameters of the operations.
     list of list of int
         The corresponding wires of the operations.
+    set of :class:`sympy.core.symbol.Symbol`
+        The free symbols in the parameters of the tket circuit.
     """
     op_list, params_list, wires_list = [], [], []
     symbols_set = set()
@@ -398,8 +402,6 @@ class PennyLaneCircuit:
 
         Parameters
         ----------
-        symbols : list of :class:`sympy.core.symbol.Symbol`
-            The symbols from the original DisCoPy circuit.
         weights : list of :class:`torch.FloatTensor`
             The weights to substitute for the symbols.
 

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -157,6 +157,7 @@ def test_Circuit_to_pennylane(capsys):
     x, y, z = sympy.symbols('x y z')
     symbols = [x, y, z]
     weights = [torch.tensor(1.), torch.tensor(2.), torch.tensor(3.)]
+    symbol_weight_map = dict(zip(symbols, weights))
 
     var_circ = Circuit(
         dom=qubit ** 0, cod=qubit, boxes=[
@@ -168,7 +169,7 @@ def test_Circuit_to_pennylane(capsys):
             3, 2, 0, 0, 0, 0, 0, 0, 1, 0])
 
     p_var_circ = var_circ.to_pennylane()
-    p_var_circ.initialise_concrete_params(symbols, weights)
+    p_var_circ.initialise_concrete_params(symbol_weight_map)
     p_var_circ.draw()
 
     captured = capsys.readouterr()
@@ -186,7 +187,7 @@ def test_Circuit_to_pennylane(capsys):
                        conc_circ.eval().array)
 
     p_var_circ_prob = var_circ.to_pennylane(probabilities=True)
-    p_var_circ_prob.initialise_concrete_params(symbols, weights)
+    p_var_circ_prob.initialise_concrete_params(symbol_weight_map)
     conc_circ_prob = (conc_circ >> Measure())
 
     assert (np.allclose(p_var_circ_prob.eval().numpy(),
@@ -288,10 +289,11 @@ def test_pennylane_uninitialized():
 def test_pennylane_parameter_reference():
     x = sympy.symbols('x')
     p = torch.nn.Parameter(torch.tensor(1.))
+    symbol_weight_map = {x: p}
 
     circ = Rx(x)
     p_circ = circ.to_pennylane()
-    p_circ.initialise_concrete_params([x], [p])
+    p_circ.initialise_concrete_params(symbol_weight_map)
 
     with torch.no_grad():
         p.add_(1.)
@@ -322,10 +324,11 @@ def test_pennylane_gradient_methods():
         weights = [torch.tensor(1., requires_grad=True),
                    torch.tensor(2., requires_grad=True),
                    torch.tensor(3., requires_grad=True)]
+        symbol_weight_map = dict(zip(symbols, weights))
 
         p_var_circ = var_circ.to_pennylane(probabilities=True,
                                            diff_method=diff_method)
-        p_var_circ.initialise_concrete_params(symbols, weights)
+        p_var_circ.initialise_concrete_params(symbol_weight_map)
 
         loss = p_var_circ.eval().norm(dim=0, p=2)
         loss.backward()
@@ -336,10 +339,11 @@ def test_pennylane_gradient_methods():
         weights = [torch.tensor(1., requires_grad=True),
                    torch.tensor(2., requires_grad=True),
                    torch.tensor(3., requires_grad=True)]
+        symbol_weight_map = dict(zip(symbols, weights))
 
         p_var_circ = var_circ.to_pennylane(probabilities=False,
                                            diff_method=diff_method)
-        p_var_circ.initialise_concrete_params(symbols, weights)
+        p_var_circ.initialise_concrete_params(symbol_weight_map)
 
         loss = p_var_circ.eval().norm(dim=0, p=2)
         loss.backward()


### PR DESCRIPTION
Currently PennyLane substitution is extremely slow, as all of the symbols and weights in the entire dataset are included in each Sympy substitution step ://. This fix ensures that only the symbols in each diagram are included, massively speeding it up.