### PR TITLE
Update pyproject.toml to fix pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,5 +103,6 @@ pythonpath = [
     "."
 ]
 testpaths = [
+    "discopy",
     "test/*/*.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,9 @@ per-file-ignores = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = [
+    "."
+]
 testpaths = [
-    "discopy",
     "test/*/*.py"
 ]


### PR DESCRIPTION
This is to fix the following error immediately after checkout

```
$ pytest test/syntax/rigid.py
=========================================================== ERRORS ============================================================
____________________________________________ ERROR collecting test/syntax/rigid.py ____________________________________________
ImportError while importing test module '/Users/martincoll/repos/colltoaction/discopy/test/syntax/rigid.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/syntax/rigid.py:3: in <module>
    from discopy.rigid import *
E   ModuleNotFoundError: No module named 'discopy'
```