### PR TITLE
YAML parsing as DisCoPy types

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [ 3.11 ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [ 3.11 ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}

--- a/discopy/discoyaml.py
+++ b/discopy/discoyaml.py
@@ -1,23 +1,43 @@
 import yaml
 
+from discopy.cat import factory
 from discopy import frobenius
 
 
 class Ob(frobenius.Ob):
     """"""
 
+@factory
 class Ty(frobenius.Ty):
     """"""
+    ob_factory = Ob
 
-class MappingBox(frobenius.Box):
+@factory
+class Diagram(frobenius.Diagram):
+    """"""
+    ob_factory = Ob
+    ty_factory = Ty
+
+class Box(frobenius.Box, Diagram):
     """"""
 
-class Box(MappingBox):
+class Category(frobenius.Category):
     """"""
+    ob, ar = Ty, Diagram
 
-def from_yaml(data: yaml.Node) -> Box:
+class Functor(frobenius.Functor):
+    """"""
+    dom = cod = Category()
+
+def from_yaml_documents(*nodes: yaml.Node) -> Box:
+    for node in nodes:
+        return from_yaml_node(node)
+
+def from_yaml_node(data: yaml.Node) -> Box:
     match data:
         case yaml.ScalarNode(value=value):
-            return frobenius.Ty(value)
+            return Ty(value)
         case yaml.MappingNode(value=[(key_node, value_node)]):
-            return frobenius.Box("f", from_yaml(key_node), from_yaml(value_node))
+            return Box("f", from_yaml_node(key_node), from_yaml_node(value_node))
+
+Id = Diagram.id

--- a/discopy/discoyaml.py
+++ b/discopy/discoyaml.py
@@ -1,0 +1,10 @@
+import yaml
+from yaml import ScalarNode
+
+from discopy.cat import Ob
+from discopy.frobenius import Diagram
+
+def from_yaml(data: yaml.Node) -> Diagram:
+    match data:
+        case ScalarNode(value=value):
+            return Ob(value)

--- a/discopy/discoyaml.py
+++ b/discopy/discoyaml.py
@@ -3,22 +3,21 @@ import yaml
 from discopy import frobenius
 
 
+class Ob(frobenius.Ob):
+    """"""
+
 class Ty(frobenius.Ty):
     """"""
 
 class MappingBox(frobenius.Box):
     """"""
 
-class SequenceBox(frobenius.Box):
-    """"""
-
-class CollectionBox(MappingBox, SequenceBox):
-    """"""
-
-class Box(Ty, CollectionBox):
+class Box(MappingBox):
     """"""
 
 def from_yaml(data: yaml.Node) -> Box:
     match data:
         case yaml.ScalarNode(value=value):
-            return Ty(value)
+            return frobenius.Ty(value)
+        case yaml.MappingNode(value=[(key_node, value_node)]):
+            return frobenius.Box("f", from_yaml(key_node), from_yaml(value_node))

--- a/discopy/discoyaml.py
+++ b/discopy/discoyaml.py
@@ -1,10 +1,24 @@
 import yaml
-from yaml import ScalarNode
 
-from discopy.cat import Ob
-from discopy.frobenius import Diagram
+from discopy import frobenius
 
-def from_yaml(data: yaml.Node) -> Diagram:
+
+class Ty(frobenius.Ty):
+    """"""
+
+class MappingBox(frobenius.Box):
+    """"""
+
+class SequenceBox(frobenius.Box):
+    """"""
+
+class CollectionBox(MappingBox, SequenceBox):
+    """"""
+
+class Box(Ty, CollectionBox):
+    """"""
+
+def from_yaml(data: yaml.Node) -> Box:
     match data:
-        case ScalarNode(value=value):
-            return Ob(value)
+        case yaml.ScalarNode(value=value):
+            return Ty(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["version"]
 name = "discopy"
 description = "The Python toolkit for computing with string diagrams."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license =  {file = "LICENSE"}
 keywords = [
     "category theory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
+  "pyyaml >= 6",
   "numpy >= 1.18.1",
   "networkx >= 2.4",
   "matplotlib >= 3.1.2",

--- a/test/discoyaml.py
+++ b/test/discoyaml.py
@@ -1,0 +1,19 @@
+import yaml
+
+from discopy.cat import *
+
+from discopy.discoyaml import from_yaml
+
+
+ob_x = from_yaml(yaml.compose("x"))
+
+
+def test_main():
+    x, y, z = ob_x, Ob('y'), Ob('z')
+    f, g, h = Box('f', x, y), Box('g', y, z), Box('h', z, x)
+    assert Id(x) >> f == f == f >> Id(y)
+    assert (f >> g).dom == f.dom and (f >> g).cod == g.cod
+    assert f >> g >> h == f >> (g >> h)
+    F = Functor(ob={x: y, y: z, z: x}, ar={f: g, g: h})
+    assert F(Id(x)) == Id(F(x))
+    assert F(f >> g) == F(f) >> F(g)

--- a/test/discoyaml.py
+++ b/test/discoyaml.py
@@ -1,11 +1,10 @@
 import yaml
 
-from discopy.frobenius import Id, Functor
 from discopy.discoyaml import *
 
 
-ob_x = from_yaml(yaml.compose("x"))
-box_x_to_y = from_yaml(yaml.compose("x: y"))
+ob_x = from_yaml_documents(yaml.compose("x"))
+box_x_to_y = from_yaml_documents(yaml.compose("x: y"))
 
 
 def test_main():

--- a/test/discoyaml.py
+++ b/test/discoyaml.py
@@ -1,16 +1,16 @@
 import yaml
 
-from discopy.cat import *
-
-from discopy.discoyaml import from_yaml
+from discopy.frobenius import Id, Functor
+from discopy.discoyaml import *
 
 
 ob_x = from_yaml(yaml.compose("x"))
+box_x_to_y = from_yaml(yaml.compose("x: y"))
 
 
 def test_main():
     x, y, z = ob_x, Ob('y'), Ob('z')
-    f, g, h = Box('f', x, y), Box('g', y, z), Box('h', z, x)
+    f, g, h = box_x_to_y, Box('g', y, z), Box('h', z, x)
     assert Id(x) >> f == f == f >> Id(y)
     assert (f >> g).dom == f.dom and (f >> g).cod == g.cod
     assert f >> g >> h == f >> (g >> h)


### PR DESCRIPTION
See https://github.com/discopy/discopy/issues/211#issuecomment-1706237680.

The goal is to transform the YAML representation graph into DisCoPy definitions:
* https://yaml.org/spec/1.2.2/#321-representation-graph.

The initial goal is to support only the structure and not tags and other features.

<img width="540" alt="image" src="https://github.com/discopy/discopy/assets/1548532/32c7d399-7792-4875-855a-3d02dc9824b2">
