### PR TITLE
Hypergraph equality context manager

### DIFF
--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -522,7 +522,7 @@ class Box(Arrow):
 
     def __eq__(self, other):
         if isinstance(other, Box):
-            return type(self) == type(other)\
+            return type(self) is type(other)\
                 and self.name == other.name\
                 and self.is_parallel(other)\
                 and self.is_dagger == other.is_dagger\
@@ -830,7 +830,7 @@ class Functor(Composable[Category]):
         self.ar: MappingOrCallable[Box, Arrow] = MappingOrCallable(ar or {})
 
     def __eq__(self, other):
-        return type(self) == type(other)\
+        return type(self) is type(other)\
             and (self.ob, self.ar, self.cod) == (other.ob, other.ar, other.cod)
 
     def __repr__(self):

--- a/discopy/compact.py
+++ b/discopy/compact.py
@@ -23,7 +23,7 @@ Axioms
 ------
 
 >>> from discopy.drawing import Equation
->>> Diagram.structure_preserving = True
+>>> Diagram.use_hypergraph_equality = True
 >>> x, y = Ty('x'), Ty('y')
 
 * Snake equations:
@@ -60,7 +60,7 @@ Axioms
 >>> assert Diagram.caps(x @ y, y.r @ x.r)\\
 ...     == Cap(x, x.r) @ Cap(y, y.r) >> x @ Diagram.swap(x.r, y @ y.r)
 
->>> Diagram.structure_preserving = False
+>>> Diagram.use_hypergraph_equality = False
 """
 
 from discopy import symmetric, ribbon

--- a/discopy/frobenius.py
+++ b/discopy/frobenius.py
@@ -30,7 +30,6 @@ Axioms
 ------
 
 >>> from discopy.drawing import Equation
->>> Diagram.structure_preserving = True
 >>> x, y, z = map(Ty, "xyz")
 
 >>> split, merge = Spider(1, 2, x), Spider(2, 1, x)
@@ -40,7 +39,8 @@ Axioms
 
 >>> frobenius = Equation(
 ...     split @ x >> x @ merge, merge >> split, x @ split >> merge @ x)
->>> assert frobenius
+>>> with Diagram.hypergraph_equality:
+...     assert frobenius
 >>> frobenius.draw(path="docs/_static/frobenius/frobenius.png")
 
 .. image:: /_static/frobenius/frobenius.png
@@ -49,10 +49,9 @@ Axioms
 * Speciality:
 
 >>> special = Equation(split >> merge, Spider(1, 1, x), Id(x))
->>> assert special
+>>> with Diagram.hypergraph_equality:
+...     assert special
 >>> special.draw(path="docs/_static/frobenius/special.png")
-
->>> Diagram.structure_preserving = False
 
 .. image:: /_static/frobenius/special.png
     :align: center

--- a/discopy/markov.py
+++ b/discopy/markov.py
@@ -24,7 +24,7 @@ Axioms
 ------
 
 >>> from discopy.drawing import Equation
->>> Diagram.structure_preserving = True
+>>> Diagram.use_hypergraph_equality = True
 >>> x = Ty('x')
 
 >>> copy, merge = Copy(x), Merge(x)
@@ -63,7 +63,7 @@ Axioms
 >>> assert Diagram.merge(x @ x)\\
 ...     == x @ Swap(x, x) @ x >> merge @ merge
 
->>> Diagram.structure_preserving = False
+>>> Diagram.use_hypergraph_equality = False
 
 Note
 ----

--- a/discopy/quantum/zx.py
+++ b/discopy/quantum/zx.py
@@ -158,8 +158,9 @@ class Diagram(tensor.Diagram[complex]):
         def node2box(node, n_legs_in, n_legs_out):
             if graph.type(node) not in {VertexType.Z, VertexType.X}:
                 raise NotImplementedError  # pragma: no cover
-            return (Z if graph.type(node) == VertexType.Z else X)(
-                n_legs_in, n_legs_out, graph.phase(node) * .5)
+            return \
+                (Z if graph.type(node) == VertexType.Z else X)(  # noqa: E721
+                    n_legs_in, n_legs_out, graph.phase(node) * .5)
 
         def move(scan, source, target):
             if target < source:
@@ -189,7 +190,7 @@ class Diagram(tensor.Diagram[complex]):
             return scan, diagram, offset
 
         missing_boundary = any(
-            graph.type(node) == VertexType.BOUNDARY
+            graph.type(node) == VertexType.BOUNDARY  # noqa: E721
             and node not in graph.inputs() + graph.outputs()
             for node in graph.vertices())
         if missing_boundary:

--- a/discopy/symmetric.py
+++ b/discopy/symmetric.py
@@ -97,13 +97,13 @@ class Diagram(balanced.Diagram):
 
     Note
     ____
-    Symmetric diagrams have a class property `structure_preserving`, that
+    Symmetric diagrams have a class property `use_hypergraph_equality`, that
     changes the behaviour of equality and hashing.
     When set to `False`, two diagrams equal if they are built from the same
     layers.
     When set to `True`, the underlying hypergraphs are used for hashing and
     equality checking.
-    The default value of `structure_preserving` is `False`.
+    The default value of `use_hypergraph_equality` is `False`.
     >>> x, y = Ty("x"), Ty("y")
     >>> id_hash = hash(Id(x @ y))
     >>> assert Swap(x, y) >> Swap(y, x) != Id(x @ y)
@@ -152,7 +152,7 @@ class Diagram(balanced.Diagram):
     by default. However now we have that the axioms for trace hold on the nose.
     """
     twist_factory = classmethod(lambda cls, dom: cls.id(dom))
-    structure_preserving = False
+    use_hypergraph_equality = False
 
     @classmethod
     def swap(cls, left: monoidal.Ty, right: monoidal.Ty) -> Diagram:
@@ -214,7 +214,7 @@ class Diagram(balanced.Diagram):
         return self.to_hypergraph().to_diagram()
 
     def _get_structure(self):
-        return self.to_hypergraph() if self.structure_preserving else (
+        return self.to_hypergraph() if self.use_hypergraph_equality else (
             self.inside, self.cod, self.dom)
 
     def __eq__(self, other):
@@ -227,11 +227,11 @@ class Diagram(balanced.Diagram):
     @classproperty
     @contextmanager
     def hypergraph_equality(cls):
-        tmp, cls.structure_preserving = cls.structure_preserving, True
+        tmp, cls.use_hypergraph_equality = cls.use_hypergraph_equality, True
         try:
             yield
         finally:
-            cls.structure_preserving = tmp
+            cls.use_hypergraph_equality = tmp
 
     def depth(self):
         """

--- a/discopy/symmetric.py
+++ b/discopy/symmetric.py
@@ -107,10 +107,9 @@ class Diagram(balanced.Diagram):
     >>> x, y = Ty("x"), Ty("y")
     >>> id_hash = hash(Id(x @ y))
     >>> assert Swap(x, y) >> Swap(y, x) != Id(x @ y)
-    >>> Diagram.structure_preserving = True
-    >>> assert Swap(x, y) >> Swap(y, x) == Id(x @ y)
-    >>> assert id_hash != hash(Id(x @ y))
-    >>> Diagram.structure_preserving = False
+    >>> with Diagram.hypergraph_equality:
+    ...     assert Swap(x, y) >> Swap(y, x) == Id(x @ y)
+    ...     assert id_hash != hash(Id(x @ y))
 
     Note
     ----

--- a/discopy/traced.py
+++ b/discopy/traced.py
@@ -29,7 +29,7 @@ Axioms
 >>> from discopy.drawing import Equation
 >>> from discopy.symmetric import Ty, Box, Swap, Id
 >>> from discopy import symmetric
->>> symmetric.Diagram.structure_preserving = True
+>>> symmetric.Diagram.use_hypergraph_equality = True
 >>> x = Ty('x')
 >>> f, g = Box('f', x @ x, x @ x), Box('g', x, x)
 
@@ -101,7 +101,7 @@ Axioms
 
 >>> assert sliding_left and sliding_right
 
->>> symmetric.Diagram.structure_preserving = False
+>>> symmetric.Diagram.use_hypergraph_equality = False
 """
 
 from discopy import monoidal

--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -678,3 +678,12 @@ def assert_istraceable(arg: Diagram, n=1, left=False):
     if traced_dom != traced_cod:
         raise AxiomError(
             messages.NOT_TRACEABLE.format(traced_dom, traced_cod))
+
+
+class classproperty(object):
+    """ Adapted from https://stackoverflow.com/a/5192374/18783670 """
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, _, x):
+        return self.f(x)


### PR DESCRIPTION
This PR allows the following syntax:

```python
with Diagram.hypergraph_equality:
    assert Swap(x, y) >> Swap(y, x) == Id(x @ y)
```