### PR TITLE
Fix Matrix.swap

### DIFF
--- a/discopy/matrix.py
+++ b/discopy/matrix.py
@@ -295,8 +295,8 @@ class Matrix(Composable[int], Whiskerable, NamedGeneric['dtype']):
         """
         dom = cod = left + right
         array = Matrix.zero(dom, cod).array
-        array[right:, :left] = Matrix.id(left).array
-        array[:right, left:] = Matrix.id(right).array
+        array[:left, right:] = Matrix.id(left).array
+        array[left:, :right] = Matrix.id(right).array
         return cls(array, dom, cod)
 
     braid = swap

--- a/discopy/matrix.py
+++ b/discopy/matrix.py
@@ -292,6 +292,8 @@ class Matrix(Composable[int], Whiskerable, NamedGeneric['dtype']):
         -------
         >>> Matrix.swap(1, 1)
         Matrix[int64]([0, 1, 1, 0], dom=2, cod=2)
+        >>> Matrix.swap(2,1)
+        Matrix[int64]([0, 1, 0, 0, 0, 1, 1, 0, 0], dom=3, cod=3)
         """
         dom = cod = left + right
         array = Matrix.zero(dom, cod).array


### PR DESCRIPTION
The order was flipped for diagrammatic order.

```python
array[:left, right:] = Matrix.id(left).array
array[left:, :right] = Matrix.id(right).array
```

![image](https://github.com/discopy/discopy/assets/13847804/0a6186f4-27dc-4563-bceb-9663a12df473)
