### PR TITLE
Fix higher-order-discocat.ipynb

### DIFF
--- a/docs/notebooks/higher-order-discocat.ipynb
+++ b/docs/notebooks/higher-order-discocat.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "### (Peirce-Lambek-Montague Semantics)\n",
     "\n",
-    "[arXiv:2311.17813](https://arxiv.org/abs/2311.17813)",
+    "[arXiv:2311.17813](https://arxiv.org/abs/2311.17813)\n",
     "\n",
     "## 1) Define Formula as a subclass of frobenius.Diagram"
    ]


### PR DESCRIPTION
Notebook doesn't get rendered properly on https://docs.discopy.org/en/main/notebooks/higher-order-discocat.html