### PR TITLE
Fix the caching mechanism of `NamedGeneric`

### DIFF
--- a/discopy/quantum/channel.py
+++ b/discopy/quantum/channel.py
@@ -153,10 +153,6 @@ class Channel(Tensor):
     """
     dtype = complex
 
-    def __class_getitem__(cls, dtype: type, _cache=dict()):
-        """ We need a fresh cache for Channel. """
-        return Tensor.__class_getitem__.__func__(cls, dtype, _cache)
-
     def __init__(self, array, dom: CQ, cod: CQ):
         assert_isinstance(dom, CQ)
         assert_isinstance(cod, CQ)

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -102,9 +102,6 @@ class Tensor(Matrix):
     ...     import jax
     ...     assert jax.grad(f)(1., 2.) == 2.
     """
-    def __class_getitem__(cls, dtype: type, _cache=dict()):
-        """ We need a fresh cache for Tensor. """
-        return Matrix.__class_getitem__.__func__(cls, dtype, _cache)
 
     def __init__(self, array, dom: Dim, cod: Dim):
         assert_isinstance(dom, Dim)

--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -148,10 +148,9 @@ class NamedGeneric(Generic[TypeVar('T')]):
                 values = values if isinstance(values, tuple) else (values,)
                 cls_values = tuple(
                     getattr(cls, attr, None) for attr in attributes)
-                if cls_values not in _cache or _cache[cls_values] != cls:
-                    _cache.clear()
-                    _cache[cls_values] = cls
-                if values not in _cache:
+                if cls not in _cache:
+                    _cache[cls] = {cls_values: cls}
+                if values not in _cache[cls]:
                     origin = getattr(cls, "__origin__", cls)
 
                     class C(origin):
@@ -163,8 +162,8 @@ class NamedGeneric(Generic[TypeVar('T')]):
                     C.__origin__ = cls
                     for attr, value in zip(attributes, values):
                         setattr(C, attr, value)
-                    _cache[values] = C
-                return _cache[values]
+                    _cache[cls][values] = C
+                return _cache[cls][values]
 
             __name__ = __qualname__\
                 = f"NamedGeneric[{', '.join(map(repr, attributes))}]"

--- a/test/syntax/utils.py
+++ b/test/syntax/utils.py
@@ -33,6 +33,17 @@ def test_deprecated_from_tree():
         assert from_tree(tree) == rigid.Id(rigid.Ty('n'))
 
 
+def test_named_generic_cache():
+    from discopy import tensor as dt
+    box, box_int, box_float = dt.Box, dt.Box[int], dt.Box[float]
+    assert box_int is dt.Box[int]
+    assert box is not box_int and box_float is not box_int
+    diag_int = dt.Diagram[int]
+    assert diag_int is dt.Diagram[int]
+    assert box_int is dt.Box[int]
+
+
+
 @pytest.mark.parametrize('fn', listdir('test/src/pickles/main/'))
 def test_pickle(fn):
     import pickle


### PR DESCRIPTION
Previously, `NamedGeneric` cleared cache whenever a new class called `__class_getitem__`. This has been modified so that the `_cache` variable is never cleared, and it contains every object now.

New tests have been added accordingly.

Closes #249