### PR TITLE
Substitute nested diagrams such as bubbles (#294)

### DIFF
--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -509,6 +509,17 @@ class Box(Arrow):
             self.name, self.dom, self.cod, is_dagger=self.is_dagger,
             data=rsubs(self.data, *args))
 
+    def substitute(self, other, indices: list[int]):
+        if len(indices) == 0:
+            assert self.is_parallel(other)
+            return self
+        if len(indices) == 1:
+            if indices[0] != 0:
+                raise ValueError("box subindex is always 0")
+            assert self.is_parallel(other)
+            return other
+        raise ValueError("too many indices")
+
     def lambdify(self, *symbols: "sympy.Symbol", **kwargs) -> Callable:
         if not any(x in self.free_symbols for x in symbols):
             return lambda *xs: self

--- a/test/syntax/monoidal.py
+++ b/test/syntax/monoidal.py
@@ -190,8 +190,8 @@ def test_Diagram_substitute():
     x = Ty("x")
     f, g, h = Box("f", x @ x @ x, x @ x), Box("g", x, x), Box("h", x @ x, x)
     inside, outside = f >> g @ g, f @ x >> x @ h
-    index_of_the_box = 0
-    result = outside.substitute(index_of_the_box, inside)
+    index_of_the_box = [0, 0, ]
+    result = outside.substitute(inside, index_of_the_box)
     assert result == inside @ x >> x @ h
 
 

--- a/test/utils/pickles/TODO/tensor_Box.py
+++ b/test/utils/pickles/TODO/tensor_Box.py
@@ -1,9 +1,0 @@
-from discopy.tensor import Box, Dim, Id, Cup
-
-
-alice = Box("Alice", Dim(1), Dim(2), [1, 2])
-eats = Box("eats", Dim(1), Dim(2, 3, 2), [3] * 12)
-food = Box("food", Dim(1), Dim(2), [4, 5])
-
-pick = alice @ eats @ food >>\
-          Cup(Dim(2), Dim(2)) @ Id(Dim(3)) @ Cup(Dim(2), Dim(2))


### PR DESCRIPTION
This should be pretty close but unfortunately I'm having difficulties with the hierarchy of python classes `Box`, `Layer`, `Diagram`, `Bubble`.

```
test/syntax/monoidal.py:194: in test_Diagram_substitute
    result = outside.substitute(inside, index_of_the_box)
discopy/monoidal.py:891: in substitute
    inside = tuple(
discopy/monoidal.py:892: in <genexpr>
    layer.substitute(other, subindices)
discopy/monoidal.py:402: in substitute
    return type(self)(left, box.substitute(other, indices), right)
discopy/monoidal.py:353: in __init__
    assert_isinstance(box, Box)
discopy/utils.py:381: TypeError: Expected monoidal.Box, got monoidal.Diagram instead.
```