### PR TITLE
Tests for closed categories

### DIFF
--- a/discopy/computer.py
+++ b/discopy/computer.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+"""
+TODO https://arxiv.org/pdf/2208.03817v4
+"""
+
+from __future__ import annotations
+
+from discopy import symmetric, closed, monoidal
+from discopy.closed import Ty
+from discopy.cat import factory
+from discopy.utils import assert_isatomic, factory_name
+
+
+@factory
+class Ty(closed.Ty):
+    """"""
+    __ambiguous_inheritance__ = (closed.Ty, )
+
+
+P = Ty("ℙ")
+
+@factory
+class Diagram(symmetric.Diagram, closed.Diagram):
+    __ambiguous_inheritance__ = True
+
+    ty_factory = Ty
+
+    # @classmethod
+    # def copy(cls, x: monoidal.Ty, n=2) -> Diagram:
+
+    # @classmethod
+    # def discard(cls, x: monoidal.Ty, n=2) -> Diagram:
+
+
+class Box(symmetric.Box, closed.Box, Diagram):
+    __ambiguous_inheritance__ = (symmetric.Box, closed.Box, )
+
+
+class Swap(symmetric.Swap, Box):
+    __ambiguous_inheritance__ = (symmetric.Swap, )
+
+
+class Trace(symmetric.Trace, Box):
+    __ambiguous_inheritance__ = (symmetric.Trace, )
+
+
+### cartesian copy
+class Copy(Box):
+    def __init__(self, x: monoidal.Ty, n: int = 2):
+        assert_isatomic(x, monoidal.Ty)
+        name = f"Copy({x}" + ("" if n == 2 else f", {n}") + ")"
+        Box.__init__(self, name, dom=x, cod=x ** n,
+                     draw_as_spider=True, color="black", drawing_name="")
+
+### cartesian discard
+class Discard(Box):
+    def __init__(self, x: monoidal.Ty):
+        assert_isatomic(x, monoidal.Ty)
+        Box.__init__(self, f"Discard({x})", dom=x, cod=Ty())
+
+
+class Eval(Box):
+    def __init__(self, base, exponent):
+        dom, cod = base, exponent
+        super().__init__("{}", P @ dom, cod)
+
+
+class Sum(symmetric.Sum, closed.Sum, Box):
+    __ambiguous_inheritance__ = (symmetric.Sum, closed.Sum, )
+
+
+class Category(symmetric.Category, closed.Category):
+    ob, ar = Ty, Diagram
+
+
+class Functor(symmetric.Functor, closed.Functor):
+    dom = cod = Category(Ty, Diagram)
+
+    def __call__(self, other):
+        if isinstance(other, Eval):
+            assert other.dom[0] == P
+            return self.cod.ar.ev(self(other.dom[1]), self(other.cod))
+        if isinstance(other, Copy):
+            return self.cod.ar.copy(self(other.dom))
+        if isinstance(other, Discard):
+            return self.cod.ar.discard(self(other.dom))
+        return super().__call__(other)
+
+
+Diagram.copy_factory = Copy
+Diagram.braid_factory = Swap
+Diagram.trace_factory = Trace
+Diagram.discard_factory = Discard
+Diagram.sum_factory = Sum
+Id = Diagram.id

--- a/test/syntax/closed.py
+++ b/test/syntax/closed.py
@@ -61,11 +61,41 @@ def test_constant_eval():
     
 
     g_eval = g >> Eval(Ty() >> y)
-    F_eval = x @ h >> Eval(x >> y)
+    h_eval = x @ h >> Eval(x >> y)
 
     test_str = "Slicing two ways!"
     assert F(f)(test_str) == len(test_str)
     assert F(f)(test_str) == F(g_eval)(test_str)
-    assert F(g_eval)(test_str) == F(F_eval)(test_str)
+    assert F(g_eval)(test_str) == F(h_eval)(test_str)
+
+
+def test_partial_eval():
+    x, y, z = map(Ty, "xyz")
     
+    f = Box("f", x @ y, z)
+    g = Box("g", Ty(), (x @ y) >> z)
+    g2 = Box("g2", Ty(), y >> (x >> z))
+    h = Box("h", y, x >> z)
+
+    g_eval = x @ y @ g >> Eval(x @ y >> z)
+    h_eval = x @ h >> Eval(x >> z)
+    g_partial_eval = (x @ ((y @ g2) >> Eval((y) >> (x >> z))) ) >> Eval(x >> z)
+
+    from discopy.python import Function
+    F = Functor(
+        ob={x: str, y: int, z: str},
+        ar={f: lambda a, b: a[:b],
+            g: lambda: lambda a, b: a[:b],
+            g2: lambda: lambda b: lambda a: a[:b],
+            h: lambda b: lambda a: a[:b],
+            },
+        cod=Category(tuple[type, ...], Function))
+    
+    test_str = "Partial evaluator"
+    str_slice = 7
+    
+    assert F(f)(test_str, str_slice) == "Partial"
+    assert F(f)(test_str, str_slice) == F(g_eval)(test_str, str_slice)
+    assert F(g_eval)(test_str, str_slice) == F(g_partial_eval)(test_str, str_slice)
+    assert F(g_partial_eval)(test_str, str_slice) == F(h_eval)(test_str, str_slice)
 

--- a/test/syntax/closed.py
+++ b/test/syntax/closed.py
@@ -43,3 +43,29 @@ def test_python_Functor():
 
     assert F(f.uncurry().curry())(True)(1j) == F(f)(True)(1j)
     assert F(g.uncurry(left=False).curry(left=False))(True)(1.2) == F(g)(True)(1.2)
+
+
+def test_constant_eval():
+    x, y = map(Ty, "xy")
+    f = Box("f", x, y)
+    g = Box("g", x, Ty() >> y)
+    h = Box("h", Ty(), x >> y)
+
+    from discopy.python import Function
+    F = Functor(
+        ob={x: str, y: int},
+        ar={f: lambda a: len(a),
+            g: lambda a: lambda: len(a),
+            h: lambda: lambda a: len(a)},
+        cod=Category(tuple[type, ...], Function))
+    
+
+    g_eval = g >> Eval(Ty() >> y)
+    F_eval = x @ h >> Eval(x >> y)
+
+    test_str = "Slicing two ways!"
+    assert F(f)(test_str) == len(test_str)
+    assert F(f)(test_str) == F(g_eval)(test_str)
+    assert F(g_eval)(test_str) == F(F_eval)(test_str)
+    
+

--- a/test/syntax/computer.py
+++ b/test/syntax/computer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from collections.abc import Callable
+
+from discopy.computer import *
+from discopy import *
+
+
+def test_python_Functor():
+    x = Ty('x')
+    copy, discard, eval = Copy(x), Discard(x), Eval(x, x)
+    add, minus = Box('+', x @ x, x), Box('-', x, x)
+
+    from discopy.python import Function
+    F = Functor(
+        ob={x: int, P: Callable[[int], tuple[int]]},
+        ar={add: lambda x, y: x+y,
+            minus: lambda x: x-1,},
+        cod=Category(tuple[type, ...], Function))
+
+    f = eval >> copy >> minus @ x >> add >> copy >> (minus @ discard)
+
+    assert F(f)(lambda x: x**3, 2) == 14


### PR DESCRIPTION
Hi, I'm learning about category theory and playing with this framework with the help of @colltoaction, we are currently following through this paper (https://arxiv.org/abs/2208.03817v4), this PR tests constant evaluators and partial evaluators. There is an intention of using partial evaluation, so we had to use a intermediary function "g2" so there isn't a type mismatch, as looking through the documentation I couldn't find a direct reference to partially apply our functions.

Adding to this last concern, is there a better way to construct partially evaluated functions from indexed programs?