### PR TITLE
Remove need for `__ambiguous_inheritance__`

### DIFF
--- a/discopy/balanced.py
+++ b/discopy/balanced.py
@@ -58,7 +58,6 @@ class Diagram(braided.Diagram, traced.Diagram):
 
     .. _nLab: https://ncatlab.org/nlab/show/traced+monoidal+category)
     """
-    __ambiguous_inheritance__ = True
 
     @classmethod
     def twist(cls, dom: monoidal.Ty) -> Diagram:
@@ -116,7 +115,6 @@ class Box(braided.Box, traced.Box, Diagram):
         dom (monoidal.Ty) : The domain of the box, i.e. its input.
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (braided.Box, traced.Box)
 
 
 class Braid(braided.Braid, Box):
@@ -137,7 +135,6 @@ class Trace(traced.Trace, Box):
     --------
     :meth:`Diagram.trace`
     """
-    __ambiguous_inheritance__ = (traced.Trace, )
 
 
 class Twist(Box):
@@ -178,7 +175,6 @@ class Sum(braided.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (braided.Sum, )
 
 
 class Category(braided.Category, traced.Category):

--- a/discopy/biclosed.py
+++ b/discopy/biclosed.py
@@ -152,7 +152,6 @@ class Exp(Ty, cat.Ob):
         base : The base type.
         exponent : The exponent type.
     """
-    __ambiguous_inheritance__ = (cat.Ob, )
 
     def __init__(self, base: Ty, exponent: Ty):
         self.base, self.exponent = base, exponent
@@ -232,7 +231,6 @@ class Diagram(monoidal.Diagram):
         dom (Ty) : The domain of the diagram, i.e. its input.
         cod (Ty) : The codomain of the diagram, i.e. its output.
     """
-    __ambiguous_inheritance__ = True
 
     ty_factory = Ty
 
@@ -283,7 +281,6 @@ class Box(monoidal.Box, Diagram):
         dom (Ty) : The domain of the box, i.e. its input.
         cod (Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (monoidal.Box, )
 
 
 class Eval(Box):
@@ -351,7 +348,6 @@ class Sum(monoidal.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (monoidal.Sum, )
 
 
 Diagram.over, Diagram.under, Diagram.exp\

--- a/discopy/braided.py
+++ b/discopy/braided.py
@@ -77,7 +77,6 @@ class Diagram(monoidal.Diagram):
         dom (monoidal.Ty) : The domain of the diagram, i.e. its input.
         cod (monoidal.Ty) : The codomain of the diagram, i.e. its output.
     """
-    __ambiguous_inheritance__ = True
 
     @classmethod
     def braid(cls, left: monoidal.Ty, right: monoidal.Ty) -> Diagram:
@@ -157,7 +156,6 @@ class Box(monoidal.Box, Diagram):
         dom (monoidal.Ty) : The domain of the box, i.e. its input.
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (monoidal.Box, )
 
 
 class Braid(BinaryBoxConstructor, Box):
@@ -226,7 +224,6 @@ class Sum(monoidal.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (monoidal.Sum, )
 
 
 class Category(monoidal.Category):

--- a/discopy/closed.py
+++ b/discopy/closed.py
@@ -106,7 +106,6 @@ class Ty(biclosed.Ty):
 
 class Exp(Ty, biclosed.Exp):
     "An exponential object in a markov category."
-    __ambiguous_inheritance__ = (biclosed.Exp, )
 
     def __str__(self):
         return f"({self.exponent} >> {self.base})"
@@ -242,26 +241,22 @@ class Diagram(markov.Diagram, biclosed.Diagram):
 
 class Box(markov.Box, biclosed.Box, Diagram):
     "A closed box is a markov and biclosed box in a closed diagram."
-    __ambiguous_inheritance__ = (markov.Box, biclosed.Box)
 
     is_linear = True
 
 
 class Eval(biclosed.Eval, Box):
     "The evaluation of an exponential type."
-    __ambiguous_inheritance__ = (biclosed.Eval, )
     drawing_name = "Eval"
 
 
 class Coeval(biclosed.Coeval, Box):
     "The coevaluation of an exponential type, i.e. the dagger of an Eval."
-    __ambiguous_inheritance__ = (biclosed.Coeval, )
     drawing_name = "$\\lambda$"
 
 
 class Curry(biclosed.Curry, Box):
     "The currying of a closed diagram."
-    __ambiguous_inheritance__ = (markov.Swap, )
 
     def to_drawing(self):
         if self.left:
@@ -273,17 +268,14 @@ class Curry(biclosed.Curry, Box):
 
 class Swap(markov.Swap, Box):
     "Symmetric swap in a closed diagram."
-    __ambiguous_inheritance__ = (markov.Swap, )
 
 
 class Trace(markov.Trace, Box):
     "A trace in a closed category."
-    __ambiguous_inheritance__ = (markov.Trace, )
 
 
 class Copy(markov.Copy, Box):
     "A markov copy in a closed category"
-    __ambiguous_inheritance__ = (markov.Copy, )
 
     is_linear = False
 
@@ -297,7 +289,6 @@ class Sum(markov.Sum, biclosed.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (markov.Sum, biclosed.Sum)
 
 
 class Category(markov.Category, biclosed.Category):

--- a/discopy/compact.py
+++ b/discopy/compact.py
@@ -86,7 +86,6 @@ class Box(symmetric.Box, ribbon.Box, Diagram):
         dom (pivotal.Ty) : The domain of the box, i.e. its input.
         cod (pivotal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (symmetric.Box, ribbon.Box, )
 
 
 class Cup(ribbon.Cup, Box):
@@ -97,7 +96,6 @@ class Cup(ribbon.Cup, Box):
         left (pivotal.Ty) : The atomic type.
         right (pivotal.Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (ribbon.Cup, )
 
 
 class Cap(ribbon.Cap, Box):
@@ -108,7 +106,6 @@ class Cap(ribbon.Cap, Box):
         left (pivotal.Ty) : The atomic type.
         right (pivotal.Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (ribbon.Cap, )
 
 
 class Swap(symmetric.Swap, ribbon.Braid, Box):
@@ -119,7 +116,6 @@ class Swap(symmetric.Swap, ribbon.Braid, Box):
         left (pivotal.Ty) : The type on the top left and bottom right.
         right (pivotal.Ty) : The type on the top right and bottom left.
     """
-    __ambiguous_inheritance__ = (symmetric.Swap, ribbon.Braid, )
 
 
 class Category(symmetric.Category, ribbon.Category):

--- a/discopy/feedback.py
+++ b/discopy/feedback.py
@@ -382,7 +382,6 @@ class Box(markov.Box, Diagram):
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
         _time_step (int) : The number of times the box has been delayed.
     """
-    __ambiguous_inheritance__ = (markov.Box, )
 
     _time_step = 0
     time_step = property(lambda self: self._time_step)

--- a/discopy/frobenius.py
+++ b/discopy/frobenius.py
@@ -102,7 +102,6 @@ class PRO(rigid.PRO, Ty):
     n : int
         The length of the PRO type.
     """
-    __ambiguous_inheritance__ = (rigid.PRO, )
 
     l = r = property(lambda self: self)
 
@@ -110,7 +109,6 @@ class PRO(rigid.PRO, Ty):
 @factory
 class Dim(monoidal.Dim, Ty):
     """ A dimension is a tuple of integers greater than one seen as a type. """
-    __ambiguous_inheritance__ = (monoidal.Dim, )
 
     l = r = property(lambda self: self.factory(*self.inside[::-1]))
 
@@ -125,7 +123,6 @@ class Diagram(compact.Diagram, markov.Diagram):
         dom (Ty) : The domain of the diagram, i.e. its input.
         cod (Ty) : The codomain of the diagram, i.e. its output.
     """
-    __ambiguous_inheritance__ = (compact.Diagram, markov.Diagram)
 
     ty_factory = Ty
 
@@ -184,7 +181,6 @@ class Box(compact.Box, markov.Box, Diagram):
         dom (Ty) : The domain of the box, i.e. its input.
         cod (Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (compact.Box, markov.Box)
 
 
 class Cup(compact.Cup, Box):
@@ -195,7 +191,6 @@ class Cup(compact.Cup, Box):
         left (Ty) : The atomic type.
         right (Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (compact.Cup, )
 
 
 class Cap(compact.Cap, Box):
@@ -206,7 +201,6 @@ class Cap(compact.Cap, Box):
         left (Ty) : The atomic type.
         right (Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (compact.Cap, )
 
 
 class Swap(compact.Swap, markov.Swap, Box):
@@ -217,7 +211,6 @@ class Swap(compact.Swap, markov.Swap, Box):
         left (Ty) : The type on the top left and bottom right.
         right (Ty) : The type on the top right and bottom left.
     """
-    __ambiguous_inheritance__ = (compact.Swap, markov.Swap)
 
     def rotate(self, left=False):
         del left
@@ -292,7 +285,6 @@ class Bubble(monoidal.Bubble, Box):
     """
     A Frobenius bubble is a monoidal bubble in a frobenius diagram.
     """
-    __ambiguous_inheritance__ = (monoidal.Bubble, )
 
 
 class Category(compact.Category, markov.Category):
@@ -303,7 +295,6 @@ class Category(compact.Category, markov.Category):
         ob : The objects of the category, default is :class:`Ty`.
         ar : The arrows of the category, default is :class:`Diagram`.
     """
-    __ambiguous_inheritance__ = (compact.Category, markov.Category)
 
     ob, ar = Ty, Diagram
 
@@ -317,7 +308,6 @@ class Functor(compact.Functor, markov.Functor):
         ar (Mapping[Box, Diagram]) : Map from :class:`Box` to :code:`cod.ar`.
         cod (Category) : The codomain of the functor.
     """
-    __ambiguous_inheritance__ = (compact.Functor, markov.Functor)
 
     dom = cod = Category()
 

--- a/discopy/markov.py
+++ b/discopy/markov.py
@@ -165,7 +165,6 @@ class Box(symmetric.Box, Diagram):
         dom (monoidal.Ty) : The domain of the box, i.e. its input.
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (symmetric.Box, )
 
 
 class Swap(symmetric.Swap, Box):
@@ -176,7 +175,6 @@ class Swap(symmetric.Swap, Box):
         left (monoidal.Ty) : The type on the top left and bottom right.
         right (monoidal.Ty) : The type on the top right and bottom left.
     """
-    __ambiguous_inheritance__ = (symmetric.Swap, )
 
 
 class Trace(symmetric.Trace, Box):
@@ -191,7 +189,6 @@ class Trace(symmetric.Trace, Box):
     --------
     :meth:`Diagram.trace`
     """
-    __ambiguous_inheritance__ = (symmetric.Trace, )
 
 
 class Copy(Box):
@@ -266,7 +263,6 @@ class Sum(symmetric.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (symmetric.Sum, )
 
 
 class Category(symmetric.Category):

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -110,7 +110,6 @@ class Ty(Ob):
     """
     ob_factory = cat.Ob
 
-    __ambiguous_inheritance__ = True
 
     def __setstate__(self, state):
         if 'inside' not in state and "_objects" in state:
@@ -947,7 +946,6 @@ class Box(cat.Box, Diagram):
     >>> assert Id(Ty()) @ f == f == f @ Id(Ty())
     >>> assert f == f[::-1][::-1]
     """
-    __ambiguous_inheritance__ = (cat.Box, )
 
     def __init__(self, name: str, dom: Ty, cod: Ty, **params):
         for attr in DRAWING_ATTRIBUTES:
@@ -981,7 +979,6 @@ class Sum(cat.Sum, Box):
     >>> print(f @ (f + f))
     (f @ x >> x @ f) + (f @ x >> x @ f)
     """
-    __ambiguous_inheritance__ = (cat.Sum, )
 
     @property
     def size(self):
@@ -1038,7 +1035,6 @@ class Bubble(cat.Bubble, Box):
         :align: center
 
     """
-    __ambiguous_inheritance__ = (cat.Bubble, )
 
     def __init__(
             self, *args: Diagram,
@@ -1091,7 +1087,6 @@ class Category(cat.Category):
         ob : The type of objects.
         ar : The type of arrows.
     """
-    __ambiguous_inheritance__ = True
 
     ob, ar = Ty, Diagram
 
@@ -1127,7 +1122,6 @@ class Functor(cat.Functor):
     .. image:: /_static/monoidal/functor-example.png
         :align: center
     """
-    __ambiguous_inheritance__ = True
 
     dom = cod = Category(Ty, Diagram)
 

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -110,7 +110,6 @@ class Ty(Ob):
     """
     ob_factory = cat.Ob
 
-
     def __setstate__(self, state):
         if 'inside' not in state and "_objects" in state:
             state["inside"] = state['_objects']

--- a/discopy/pivotal.py
+++ b/discopy/pivotal.py
@@ -93,7 +93,6 @@ class PRO(rigid.PRO, Ty):
     n : int
         The length of the PRO type.
     """
-    __ambiguous_inheritance__ = (rigid.PRO, )
     l = r = property(lambda self: self)
 
 
@@ -182,7 +181,6 @@ class Box(rigid.Box, Diagram):
         dom (Ty) : The domain of the box, i.e. its input.
         cod (Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (rigid.Box, )
 
     def rotate(self, left=False):
         del left
@@ -214,7 +212,6 @@ class Cup(rigid.Cup, Box):
         left (Ty) : The atomic type.
         right (Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (rigid.Cup, )
 
     def dagger(self) -> Cap:
         """ The dagger of a pivotal cup. """
@@ -229,7 +226,6 @@ class Cap(rigid.Cap, Box):
         left (Ty) : The atomic type.
         right (Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (rigid.Cap, )
 
     def dagger(self) -> Cup:
         """ The dagger of a pivotal cap. """

--- a/discopy/python/additive.py
+++ b/discopy/python/additive.py
@@ -44,7 +44,6 @@ class Function(function.Function):
             swap
             trace
     """
-    __ambiguous_inheritance__ = True
 
     ty_factory = Ty
 

--- a/discopy/python/multiplicative.py
+++ b/discopy/python/multiplicative.py
@@ -71,7 +71,6 @@ class Function(function.Function):
             fix
             trace
     """
-    __ambiguous_inheritance__ = True
 
     ty_factory = Ty
 

--- a/discopy/quantum/zx.py
+++ b/discopy/quantum/zx.py
@@ -234,7 +234,6 @@ class Box(tensor.Box[complex], Diagram):
         dom (rigid.PRO) : The domain of the box, i.e. its input.
         cod (rigid.PRO) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (tensor.Box, )
 
 
 class Sum(tensor.Sum[complex], Box):
@@ -246,7 +245,6 @@ class Sum(tensor.Sum[complex], Box):
         dom (Dim) : The domain of the formal sum.
         cod (Dim) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (tensor.Sum, )
 
 
 class Swap(tensor.Swap[complex], Box):

--- a/discopy/ribbon.py
+++ b/discopy/ribbon.py
@@ -138,7 +138,6 @@ class Box(pivotal.Box, balanced.Box, Diagram):
         dom (pivotal.Ty) : The domain of the box, i.e. its input.
         cod (pivotal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (pivotal.Box, balanced.Box, )
 
 
 class Cup(pivotal.Cup, Box):
@@ -149,7 +148,6 @@ class Cup(pivotal.Cup, Box):
         left (pivotal.Ty) : The atomic type.
         right (pivotal.Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (pivotal.Cup, )
 
 
 class Cap(pivotal.Cap, Box):
@@ -160,7 +158,6 @@ class Cap(pivotal.Cap, Box):
         left (pivotal.Ty) : The atomic type.
         right (pivotal.Ty) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (pivotal.Cap, )
 
 
 class Braid(balanced.Braid, Box):
@@ -172,7 +169,6 @@ class Braid(balanced.Braid, Box):
         right (pivotal.Ty) : The type on the top right and bottom left.
         is_dagger (bool) : Braiding over or under.
     """
-    __ambiguous_inheritance__ = (balanced.Braid, )
 
     z = 0
 
@@ -208,7 +204,6 @@ class Sum(rigid.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (rigid.Sum, )
 
 
 class Category(pivotal.Category, balanced.Category):

--- a/discopy/rigid.py
+++ b/discopy/rigid.py
@@ -70,7 +70,6 @@ class Ob(cat.Ob):
     >>> a = Ob('a')
     >>> assert a.l.r == a.r.l == a and a != a.l.l != a.r.r
     """
-    __ambiguous_inheritance__ = True
 
     def __setstate__(self, state):
         if '_z' in state:  # Backward compatibility
@@ -185,7 +184,6 @@ class PRO(monoidal.PRO, Ty):
     n : int
         The length of the PRO type.
     """
-    __ambiguous_inheritance__ = (monoidal.PRO, )
     l = r = property(lambda self: self)
 
 
@@ -229,7 +227,6 @@ class Diagram(biclosed.Diagram):
     .. image:: /_static/rigid/diagram-example.png
         :align: center
     """
-    __ambiguous_inheritance__ = True
 
     ty_factory = Ty
     layer_factory = Layer
@@ -557,7 +554,6 @@ class Box(biclosed.Box, Diagram):
     >>> assert f.r.l == f == f.l.r
     >>> assert f.l.l != f != f.r.r
     """
-    __ambiguous_inheritance__ = (biclosed.Box, )
 
     def __setstate__(self, state):
         if '_z' in state:  # Backward compatibility
@@ -614,7 +610,6 @@ class Sum(biclosed.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (biclosed.Sum, )
 
     def rotate(self, left=False) -> Sum:
         if left:

--- a/discopy/symmetric.py
+++ b/discopy/symmetric.py
@@ -270,7 +270,6 @@ class Box(balanced.Box, Diagram):
         dom (monoidal.Ty) : The domain of the box, i.e. its input.
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (balanced.Box, )
 
     def __hash__(self):
         if self.use_hypergraph_equality:
@@ -312,7 +311,6 @@ class Trace(balanced.Trace, Box):
     --------
     :meth:`Diagram.trace`
     """
-    __ambiguous_inheritance__ = (balanced.Trace, )
     __eq__, __hash__ = Diagram.__eq__, Diagram.__hash__
 
     def _get_structure(self):
@@ -329,7 +327,6 @@ class Sum(balanced.Sum, Box):
         dom (Ty) : The domain of the formal sum.
         cod (Ty) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (balanced.Sum, )
 
 
 class Category(balanced.Category):

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -586,7 +586,6 @@ class Box(frobenius.Box, Diagram):
     >>> b1.eval()
     Tensor[float64]([0.84193562, 0.91343221], dom=Dim(1), cod=Dim(2))
     """
-    __ambiguous_inheritance__ = (frobenius.Box, )
 
     def __setstate__(self, state):
         NamedGeneric.__setstate__(self, state)
@@ -637,7 +636,6 @@ class Cup(frobenius.Cup, Box):
         left (Dim) : The atomic type.
         right (Dim) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (frobenius.Cup, )
 
 
 class Cap(frobenius.Cap, Box):
@@ -648,7 +646,6 @@ class Cap(frobenius.Cap, Box):
         left (Dim) : The atomic type.
         right (Dim) : Its adjoint.
     """
-    __ambiguous_inheritance__ = (frobenius.Cap, )
 
 
 class Swap(frobenius.Swap, Box):
@@ -659,7 +656,6 @@ class Swap(frobenius.Swap, Box):
         left (Dim) : The type on the top left and bottom right.
         right (Dim) : The type on the top right and bottom left.
     """
-    __ambiguous_inheritance__ = (frobenius.Swap, )
 
 
 class Spider(frobenius.Spider, Box):
@@ -684,7 +680,6 @@ class Spider(frobenius.Spider, Box):
     .. image:: /_static/tensor/frobenius-example.png
         :align: center
     """
-    __ambiguous_inheritance__ = (frobenius.Spider, )
 
 
 class Sum(monoidal.Sum, Box):
@@ -696,7 +691,6 @@ class Sum(monoidal.Sum, Box):
         dom (Dim) : The domain of the formal sum.
         cod (Dim) : The codomain of the formal sum.
     """
-    __ambiguous_inheritance__ = (monoidal.Sum, )
 
 
 class Bubble(monoidal.Bubble, Box):
@@ -742,7 +736,6 @@ class Bubble(monoidal.Bubble, Box):
     .. image:: /_static/tensor/product-rule.png
         :align: center
     """
-    __ambiguous_inheritance__ = (monoidal.Bubble, )
 
     def __init__(self, inside, func=lambda x: int(not x), **params):
         self.func = func

--- a/discopy/traced.py
+++ b/discopy/traced.py
@@ -176,7 +176,6 @@ class Box(monoidal.Box, Diagram):
         dom (monoidal.Ty) : The domain of the box, i.e. its input.
         cod (monoidal.Ty) : The codomain of the box, i.e. its output.
     """
-    __ambiguous_inheritance__ = (monoidal.Box, )
 
 
 class Trace(Box, monoidal.Bubble):

--- a/docs/_ext/bases-fullname.py
+++ b/docs/_ext/bases-fullname.py
@@ -5,12 +5,11 @@ Add an attribute `__ambiguous_inheritance__: bool | list[type]` to your class.
 """
 
 def process_bases(app, name, obj, options, bases):
-    ambiguity = getattr(obj, "__ambiguous_inheritance__", False)
-    if isinstance(ambiguity, bool):
-        ambiguity = bases if ambiguity else ()
-    for i, base in enumerate(bases):
-        if base in ambiguity:
-            bases[i] = ":class:`{}.{}`".format(base.__module__, base.__name__)
+    if isinstance(obj, type):
+        ambiguity = set(base for base in obj.__bases__ if base.__module__ is not obj.__module__)
+        for i, base in enumerate(bases):
+            if base in ambiguity:
+                bases[i] = ":class:`{}.{}`".format(base.__module__, base.__name__)
 
 
 def setup(app):


### PR DESCRIPTION
Instead, compute `__ambiguous_inheritance__` programmatically in the Sphinx plugin.
