### PR TITLE
Fix Read the Docs build by upgrading Python from 3.11 to 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,32 @@ env:
   DOCS_DIR: docs
 
 jobs:
+  check-config:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check RTD Python version matches pyproject.toml requires-python
+      run: |
+        python3 -c "
+        import tomllib, re, sys
+        with open('pyproject.toml', 'rb') as f:
+            data = tomllib.load(f)
+        req = data['project']['requires-python']
+        m = re.search(r'>=(\d+\.\d+)', req)
+        if not m:
+            print(f'Could not parse requires-python: {req}'); sys.exit(1)
+        min_py = m.group(1)
+        with open('.readthedocs.yaml') as f:
+            rtd = f.read()
+        m = re.search(r'python:\s+\"(\d+\.\d+)\"', rtd)
+        if not m:
+            print('Could not parse Python version from .readthedocs.yaml'); sys.exit(1)
+        rtd_py = m.group(1)
+        if min_py != rtd_py:
+            print(f'MISMATCH: pyproject.toml requires Python >={min_py} but .readthedocs.yaml specifies {rtd_py}')
+            sys.exit(1)
+        print(f'OK: both specify Python {min_py}')
+        "
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,32 +13,6 @@ env:
   DOCS_DIR: docs
 
 jobs:
-  check-config:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Check RTD Python version matches pyproject.toml requires-python
-      run: |
-        python3 -c "
-        import tomllib, re, sys
-        with open('pyproject.toml', 'rb') as f:
-            data = tomllib.load(f)
-        req = data['project']['requires-python']
-        m = re.search(r'>=(\d+\.\d+)', req)
-        if not m:
-            print(f'Could not parse requires-python: {req}'); sys.exit(1)
-        min_py = m.group(1)
-        with open('.readthedocs.yaml') as f:
-            rtd = f.read()
-        m = re.search(r'python:\s+\"(\d+\.\d+)\"', rtd)
-        if not m:
-            print('Could not parse Python version from .readthedocs.yaml'); sys.exit(1)
-        rtd_py = m.group(1)
-        if min_py != rtd_py:
-            print(f'MISMATCH: pyproject.toml requires Python >={min_py} but .readthedocs.yaml specifies {rtd_py}')
-            sys.exit(1)
-        print(f'OK: both specify Python {min_py}')
-        "
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
The package now requires Python >=3.12 but .readthedocs.yaml was still
specifying 3.11, causing the RTD build to fail with:
"Package 'discopy' requires a different Python: 3.11.14 not in '>=3.12'"

Also update the OS from ubuntu-20.04 to ubuntu-22.04 which is the
recommended base for Python 3.12 on RTD.

https://claude.ai/code/session_01GjB8cX4s8RthLrT2JmLN9J