### PR TITLE
docs: remove stale Application entry from categorial autosummary

### DIFF
--- a/discopy/grammar/categorial.py
+++ b/discopy/grammar/categorial.py
@@ -14,7 +14,6 @@ Summary
     TermBase
     Constant
     Variable
-    Application
     Abstraction
     FA
     BA


### PR DESCRIPTION
The module docstring of `discopy.grammar.categorial` lists `Application` in its autosummary block, but the module has no such attribute — forward and backward application are `FA` and `BA` (both subclasses of `biclosed.Application`), which are already listed.

This made every docs build emit:

```
WARNING: [autosummary] failed to import discopy.grammar.categorial.Application.
```

and made `sphinx-build -W docs docs/_build` fail outright (CI builds without `-W`, so it only showed up as a warning there).

Verified with `uv run --group all sphinx-build docs docs/_build`: the import warning is gone and stubs for `FA`/`BA` still generate. The stale entry appears to date back to #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)