### PR TITLE
Fix ob/ar keywords in composition benchmark

### DIFF
--- a/benchmark/test_composition.py
+++ b/benchmark/test_composition.py
@@ -184,8 +184,8 @@ def _full_adder():
 
 def _adder_functor(full_adder):
     return Functor(
-        ob={full_adder.dom[:1]: int},
-        ar={full_adder: full_adder_function}, cod=Function)
+        ob_map={full_adder.dom[:1]: int},
+        ar_map={full_adder: full_adder_function}, cod=Function)
 
 
 # --- k-fold tensor ---------------------------------------------------------


### PR DESCRIPTION
PR #369 renamed the `Functor` constructor keywords `ob`/`ar` to `ob_map`/`ar_map`, but missed the `_adder_functor` call site in `benchmark/test_composition.py`. This broke the `test_adder_step_*` benchmark cases with a `TypeError`.

This one-line-per-keyword fix updates the call site accordingly. Verified with `pytest benchmark/test_composition.py -k adder` (13 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)