### PR TITLE
Speed up Ty construction (assert_isinstance + lazy name)

### DIFF
--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -239,7 +239,9 @@ class Ty(cat.Ob, FreeMonoid):
                 (cat.Ob, ) if self.generator_factory is Wire else ()))
         inside = tuple(map(self.cast_wire, inside))
         FreeMonoid.__init__(self, inside, dom, cod, _scan)
-        cat.Ob.__init__(self, str(self))
+        # ``name`` is computed lazily by ``__getattr__``: building ``str(self)``
+        # on every construction dominates the cost when hypergraphs iterate
+        # over box domains (each element access builds a fresh singleton Ty).
 
     def count(self, obj: cat.Ob) -> int:
         """
@@ -288,6 +290,15 @@ class Ty(cat.Ob, FreeMonoid):
             parts.append(f'{name}("")' if s == '' else s)
         return ' @ '.join(parts)
 
+    def __getattr__(self, attr):
+        # ``name`` is derived from ``inside`` (see ``__init__``); compute it on
+        # first access and cache it so repeated reads stay cheap.
+        if attr == "name":
+            name = self.__dict__["name"] = str(self)
+            return name
+        raise AttributeError(
+            f"{factory_name(type(self))!r} object has no attribute {attr!r}")
+
     def __iter__(self):
         for i in range(len(self)):
             yield self[i]
@@ -307,9 +318,8 @@ class Ty(cat.Ob, FreeMonoid):
             state['dom'] = white
         if 'cod' not in state:
             state['cod'] = white
+        state.pop('name', None)  # recomputed lazily by __getattr__
         self.__dict__.update(state)
-        if not hasattr(self, 'name'):
-            self.name = str(self)
 
     def to_tree(self):
         tree = {

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -239,9 +239,10 @@ class Ty(cat.Ob, FreeMonoid):
                 (cat.Ob, ) if self.generator_factory is Wire else ()))
         inside = tuple(map(self.cast_wire, inside))
         FreeMonoid.__init__(self, inside, dom, cod, _scan)
-        # ``name`` is computed lazily by ``__getattr__``: building ``str(self)``
-        # on every construction dominates the cost when hypergraphs iterate
-        # over box domains (each element access builds a fresh singleton Ty).
+        # ``name`` is computed lazily by ``__getattr__``: building
+        # ``str(self)`` on every construction dominates the cost when
+        # hypergraphs iterate over box domains (each element access builds
+        # a fresh singleton Ty).
 
     def count(self, obj: cat.Ob) -> int:
         """

--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -285,8 +285,8 @@ def is_tuple(typ: type) -> bool:
 def assert_isinstance(object_, cls: type | tuple[type, ...]):
     """ Raise ``TypeError`` if ``object`` is not instance of ``cls``. """
     classes = cls if isinstance(cls, tuple) else (cls, )
-    cls_name = ' | '.join(map(factory_name, classes))
     if not any(isinstance(object_, get_origin(cls)) for cls in classes):
+        cls_name = ' | '.join(map(factory_name, classes))
         raise TypeError(messages.TYPE_ERROR.format(
             cls_name, factory_name(type(object_))))
 


### PR DESCRIPTION
> the colours seem to have slowed down the hypergraph, try to identify where exactly

## What

Fixes a performance regression in hypergraph construction/hashing introduced by the 2-categories syntax refactor (#354).

That refactor rebuilt `monoidal.Ty` on top of `cat.FreeCategory` so types carry region colours (`Colour`/`Wire`). As a result every `Ty` construction got noticeably heavier. Hypergraph construction and hashing iterate over each box's `dom`/`cod`, and every element access (`t[i]`, `for obj in t`) builds a fresh singleton `Ty`, so that per-`Ty` cost compounds across the whole hypergraph — which is where the slowdown surfaced.

Two independent hot-path costs are addressed, one per commit:

**1. `assert_isinstance` built its error string on every call.** It eagerly computed
```python
cls_name = ' | '.join(map(factory_name, classes))
```
before the check, so the success path (the overwhelmingly common case) paid for an error message it discarded. `factory_name` does per-class string work (`removeprefix`/`join`), and #354 raised the number of `assert_isinstance` calls per `Ty` from 4 to ~7.

**2. `Ty.__init__` eagerly built and stored `str(self)` as `name`.** The final `cat.Ob.__init__(self, str(self))` computed the joined string name on every construction. But `Ty` overrides `__str__`, `__repr__`, `__eq__` and `__hash__` — none read `self.name` — so the stored name is only consumed by the inherited `Ob.__lt__` and rare external callers, never on the hypergraph hot path.

## How

1. Move the `cls_name` computation inside the failure branch of `assert_isinstance`, so it is built only when the assertion actually raises. The error message is unchanged.

2. Drop the eager name computation in `Ty.__init__` and derive `name` lazily via `__getattr__`, caching it in `__dict__` on first access. `__getattr__` (rather than a property) avoids clashing with the direct `self.name = ...` assignments in subclasses such as `PRO`; `__setstate__` no longer recomputes the name either.

## Impact

Staircase-snake `to_hypergraph` and singleton `Ty` construction (CPU time):

| op | before #354 | main | + fix 1 | + fix 2 (this PR) |
|---|---|---|---|---|
| `Ty("x")` | 5.9 µs | 10.8 µs | 6.3 µs | **4.1 µs** |
| `to_hypergraph(n=8)` | 0.645 s | 0.760 s | 0.618 s | **0.408 s** |

Net result is ~2× faster than `main` and comfortably below the pre-#354 baseline.

Verified: `test/syntax` (monoidal, hypergraph, symmetric, rigid, cat, frobenius, pivotal, compact), `test/utils` pickle round-trips including 0.6 version-compatibility, and `test/grammar`/`test/drawing` all pass. Also checked directly: name access, equality/hash, `<` ordering, `to_drawing`, coloured types, `PRO`, and pickle/deepcopy round-trips. The only failing doctests in the tree are missing optional backends (`pytket`, `pyzx`, `quimb`, `tensornetwork`, `nltk`) and fail identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)