### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why

Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md` — there is no native `AGENTS.md` support ([docs](https://code.claude.com/docs/en/memory#agents-md)). So contributors using Claude Code have to ask it to read `AGENTS.md` by hand at the start of every session, which is easy to forget and annoying to repeat.

## What

A one-line `CLAUDE.md` that imports the existing `AGENTS.md`:

```
@AGENTS.md
```

No instructions are duplicated: `AGENTS.md` stays the single source of truth (and keeps working for other agents that read it directly).

## How

The `@path` import is the mechanism Claude Code's docs recommend for exactly this case. At launch it pulls `AGENTS.md` into context, and since `AGENTS.md` itself imports `@README.md` and `@CONTRIBUTING.md`, those load through it too — a two-hop chain, within Claude Code's four-hop import limit. The first session after this lands shows a one-time approval dialog for the imported files; after that they load automatically every session. A `CLAUDE.md -> AGENTS.md` symlink would also work but is messier on Windows, so the import is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cBHHaz3LW1nbmSNjQxHdW)_