### PR TITLE
hypergraph: compute the ports once in Hypergraph.__init__

### DIFF
--- a/discopy/hypergraph.py
+++ b/discopy/hypergraph.py
@@ -213,10 +213,11 @@ class Hypergraph(MonoidalCategory, NamedGeneric['category']):
         flat_wires = dom_wires + sum(
             [x + y for x, y in box_wires], ()) + cod_wires
         connected_spiders = set(flat_wires)
+        ports = self.ports
 
         if spider_types is None:
             spider_types = {spider: port.obj for spider, port in zip(
-                flat_wires, self.ports)}
+                flat_wires, ports)}
         if not isinstance(spider_types, Mapping):
             spider_types = dict(enumerate(spider_types))
 
@@ -233,13 +234,13 @@ class Hypergraph(MonoidalCategory, NamedGeneric['category']):
         for obj, (producers, consumers) in zip(
                 self.spider_types, self.spider_wires):
             for i in producers | consumers:
-                if self.ports[i].obj.unwind() != obj:
+                if ports[i].obj.unwind() != obj:
                     raise AxiomError(messages.TYPE_ERROR.format(
-                        obj, self.ports[i].obj))
+                        obj, ports[i].obj))
             same_side = producers if len(producers) == 2 else\
                 consumers if len(consumers) == 2 else None
             if same_side is not None:
-                left, right = (self.ports[i].obj for i in sorted(same_side))
+                left, right = (ports[i].obj for i in sorted(same_side))
                 if getattr(left, "r", left) != right\
                         and getattr(right, "r", right) != left:
                     raise AxiomError(messages.NOT_ADJOINT.format(left, right))


### PR DESCRIPTION
Prompted by @giodefelice while diagnosing the cancelled benchmark job on #408 (quoted verbatim, per the LLM contribution guidelines):

> The benchmarks in CI are not passing, I don't understand why since your code should not have added any new benchmarks. Can you find what the problem is? [...] that test should take linear time indeed, why is it taking so much longer?

Implementation is LLM-written (Claude Code); full diagnosis in #432. Closes #432.

## The problem

`Hypergraph.__init__` evaluated `self.ports` — an uncached property that rebuilds the full port list, one `Node` and one sliced `Ty` per port — **inside the innermost validation loops**, making every construction quadratic in the number of ports. `Hypergraph.from_diagram` folds a diagram layer-by-layer through `tensor`/`then`, one fresh `Hypergraph` per layer, so converting a snake-heavy diagram was cubic overall. This is what `test_transpose_equality_hypergraph` was measuring (equality itself takes ~1ms — the monogamous fast path is fine; the cost was hidden in `to_hypergraph`), and what pushed the benchmark job to 14:39 against its 15:00 backstop, cancelling the run on #408 on runner jitter.

## The fix

Compute `ports` once — it depends only on `dom`, `boxes` and `cod`, assigned once at the top of `__init__` and never mutated — and use the local at the three call sites. Five lines changed, no behaviour change.

`to_hypergraph() + ==` on the benchmark's snake workload, same machine:

| n | before | after |
|---|---|---|
| 10 | 0.58s | 0.06s |
| 20 | 4.24s | 0.23s |
| 50 | 59.0s | 1.57s |

(CI, before: 126–174s at n = 50.) The four `transpose_equality_hypergraph` benchmark cases drop from ~12 minutes to ~9 seconds, putting the whole PR-smoke benchmark job at a few minutes.

The residual super-linearity (the `.index`-based relabeling, also noted in #432) is benign at these sizes and left untouched to keep the diff minimal.

## Verification

`pflake8` clean; `pylint` 8.70 (up from 8.66); full `coverage run -m pytest` suite green at the 98% gate; `pytest benchmark/ -k transpose_equality` passes in 9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
