### PR TITLE
CLAUDE.md includes RULES.md and STYLE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
 @AGENTS.md
+@RULES.md
+@STYLE.md

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO.md
+
+> let's open a PR to do the same with DisCoPy and @STYLE.md and @RULES.md
+
+- [WIP] @daylight-2026-07-26 21:00 — CLAUDE.md includes RULES.md and STYLE.md alongside AGENTS.md,
+  so every session loads them up front instead of being told to go read them

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-# TODO.md
-
-> let's open a PR to do the same with DisCoPy and @STYLE.md and @RULES.md
-
-- [x] CLAUDE.md includes RULES.md and STYLE.md alongside AGENTS.md,
-  so every session loads them up front instead of being told to go read them

--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,5 @@
 
 > let's open a PR to do the same with DisCoPy and @STYLE.md and @RULES.md
 
-- [WIP] @daylight-2026-07-26 21:00 — CLAUDE.md includes RULES.md and STYLE.md alongside AGENTS.md,
+- [x] CLAUDE.md includes RULES.md and STYLE.md alongside AGENTS.md,
   so every session loads them up front instead of being told to go read them


### PR DESCRIPTION
> let's open a PR to do the same with DisCoPy and @STYLE.md and @RULES.md

Same trick as [toumix.github.io#6](https://github.com/toumix/toumix.github.io/pull/6): AGENTS.md tells agents to read RULES.md and STYLE.md before any work, but an instruction to read is not the same as having read — a session's first turns happen before it tool-calls its way to the files. CLAUDE.md now includes all three, so they are in context up front.

Markdown-only change; the test suite doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7EfPRMaNuRwviuWiuaTyF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7EfPRMaNuRwviuWiuaTyF)_