### PR TITLE
Define "ready for sign-off" in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,8 @@ Before pushing anything, make sure that:
 - you have `uv run` both `pflake8 discopy` and `coverage run -m pytest` as described in @CONTRIBUTING.md
 - you have respected the [code style guide](CONTRIBUTING.md#code-style-guide)
 
-A pull request is **ready for sign-off** when all four of these hold:
+A pull request is **ready for sign-off** when all three of these hold:
 
 1) every point of its `TODO.md` is `[x]`, the rest filed as issues
-2) CI is green on the real jobs
+2) CI is green on the real jobs, with the target branch merged in
 3) no review thread is waiting on an agent, i.e. every thread is either resolved or waiting on human feedback
-4) it is not behind its target branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,9 @@ Before pushing anything, make sure that:
 - you have `uv run` both `pflake8 discopy` and `coverage run -m pytest` as described in @CONTRIBUTING.md
 - you have respected the [code style guide](CONTRIBUTING.md#code-style-guide)
 
-A pull request is **ready for sign-off** when all four of these hold, and whatever
-reports readiness says which one fails rather than rounding to an impression:
+A pull request is **ready for sign-off** when all four of these hold:
 
 1) every point of its `TODO.md` is `[x]`, the rest filed as issues
 2) CI is green on the real jobs
-3) no unresolved review thread is waiting on an agent, i.e. every instruction has landed
+3) no review thread is waiting on an agent, i.e. every thread is either resolved or waiting on human feedback
 4) it is not behind its target branch
-
-Clause 3) is about direction, not count: a thread waiting on a human *is* the sign-off,
-so a pull request can be ready with unresolved threads and merge with them still open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,14 @@ Before pushing anything, make sure that:
 - you have added docs and tests that are complete but concise as best as you can
 - you have `uv run` both `pflake8 discopy` and `coverage run -m pytest` as described in @CONTRIBUTING.md
 - you have respected the [code style guide](CONTRIBUTING.md#code-style-guide)
+
+A pull request is **ready for sign-off** when all four of these hold, and whatever
+reports readiness says which one fails rather than rounding to an impression:
+
+1) every point of its `TODO.md` is `[x]`, the rest filed as issues
+2) CI is green on the real jobs
+3) no unresolved review thread is waiting on an agent, i.e. every instruction has landed
+4) it is not behind its target branch
+
+Clause 3) is about direction, not count: a thread waiting on a human *is* the sign-off,
+so a pull request can be ready with unresolved threads and merge with them still open.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-# TODO
-
-> fix this https://github.com/discopy/discopy/issues/498
-
-- [x] state readiness as a four-clause conjunction in `AGENTS.md`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+> fix this https://github.com/discopy/discopy/issues/498
+
+- [ ] state readiness as a four-clause conjunction in `AGENTS.md`

--- a/TODO.md
+++ b/TODO.md
@@ -2,4 +2,4 @@
 
 > fix this https://github.com/discopy/discopy/issues/498
 
-- [WIP] @3b79400c-2026-07-29 09:00 state readiness as a four-clause conjunction in `AGENTS.md`
+- [x] state readiness as a four-clause conjunction in `AGENTS.md`

--- a/TODO.md
+++ b/TODO.md
@@ -2,4 +2,4 @@
 
 > fix this https://github.com/discopy/discopy/issues/498
 
-- [ ] state readiness as a four-clause conjunction in `AGENTS.md`
+- [WIP] @3b79400c-2026-07-29 09:00 state readiness as a four-clause conjunction in `AGENTS.md`


### PR DESCRIPTION
## Why

Closes #498. Human prompt, verbatim:

> fix this https://github.com/discopy/discopy/issues/498

Readiness gets computed as `TODO.md` all `[x]` + CI green. Neither carries any information about review threads, so a pull request can read "ready" while an instruction on it sits unactioned — #440 was listed ready on two consecutive plans while carrying an unresolved comment asking to delete the class it adds, and #362 was filed "blocked on the reviewer" for four cycles while owing eleven instructions from the 2026-07-24 pass.

The scope is Alexis' on [toumix/desire#5](https://github.com/toumix/desire/issues/5):

> it's fine to have unresolved threads if they are truly waiting on the user's feedback, so it should be about zero unresolved threads where the agents is expected to act

and, on where it belongs:

> this is a discopy/AGENTS.md problem, open an issue there instead

## What

Five lines at the end of `## How` in `AGENTS.md`, stating readiness as a conjunction of three clauses:

1) every point of its `TODO.md` is `[x]`, the rest filed as issues
2) CI is green on the real jobs, with the target branch merged in
3) no review thread is waiting on an agent, i.e. every thread is either resolved or waiting on human feedback

## How

- **Clause 3) counts threads waiting on an agent, not unresolved threads.** A flat "zero unresolved" would have called #360 not ready, and it merged with 25 unresolved threads — all the reviewer's own — correctly. The clause spells out the two ways a thread passes: resolved, or waiting on human feedback.
- **Clause 2) is one clause, not two.** Green CI and an up-to-date branch are the same fact: a green run on a branch that is behind is evidence about a commit nobody is merging. `RULES.md` rule 3 already says how the target gets in — merge it, never rebase — so the clause names the state and not the procedure.
- **`AGENTS.md`, not `RULES.md`.** `RULES.md` binds an agent to what it does on a branch; readiness is a judgement anyone makes *about* a pull request from the outside, which is `AGENTS.md`'s register. It sits at the end of `## How`, right after the before-you-push list, since it is the same kind of check one step later.
- Clause 1) says "the rest filed as issues" to stay consistent with `RULES.md` rule 1 rather than restate it, and clause 2) says "real jobs" so a skipped or neutral check does not read as green.
- The clauses stand on their own: Alexis cut the framing sentences in review (3524c4e) and merged the CI and up-to-date clauses (20d3bf9).

Documentation only, no Python touched. `uv run pflake8 discopy` is clean; the test suite is unaffected by a markdown change and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAhFAf48JJR9yjZVk8VC6r
