### PR TITLE
Time out build.yml jobs instead of hanging for hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      timeout-minutes: 3
+      # A stalled mirror sends nothing for apt's default 120s read timeout,
+      # so bound each request to 10s and let apt fail over to the next mirror.
+      timeout-minutes: 5
       run: |
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install -y graphviz
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 install -y graphviz
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -98,10 +100,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      timeout-minutes: 3
+      # A stalled mirror sends nothing for apt's default 120s read timeout,
+      # so bound each request to 10s and let apt fail over to the next mirror.
+      timeout-minutes: 5
       run: |
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install -y graphviz
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 install -y graphviz
     - name: Install
       run:
         uv sync --locked --group docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,18 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # A stalled mirror can trickle bytes past any apt read timeout (#591),
-      # so bound each call by wall clock and retry once on a fresh connection.
-      timeout-minutes: 10
+      # #591: `apt-get update` refreshes six unrelated repos (azure-cli,
+      # chrome, microsoft, three Ubuntu components) to install one stable
+      # core package, and its index downloads were the actual site of every
+      # hang — bounded to 120s each, they still legitimately took ~120s
+      # against archive.ubuntu.com once azure failed over, so retrying
+      # `update` itself just paid that cost twice. The runner image ships
+      # pre-populated apt lists, so install directly first and only pay for
+      # `update` as a bounded, retried fallback if that cache is stale.
+      timeout-minutes: 6
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
-        $APT update && $APT install -y graphviz \
-          || { $APT update && $APT install -y graphviz; }
+        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
         dot -V
     - name: Install
       run:
@@ -102,13 +107,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # A stalled mirror can trickle bytes past any apt read timeout (#591),
-      # so bound each call by wall clock and retry once on a fresh connection.
-      timeout-minutes: 10
+      # See the identical step in `test` above for why this skips `update`.
+      timeout-minutes: 6
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
-        $APT update && $APT install -y graphviz \
-          || { $APT update && $APT install -y graphviz; }
+        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
         dot -V
     - name: Install
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15   # backstop: green runs take ~6 min; a job wedged on its first network step reports nothing for hours (#591)
     strategy:
       matrix:
         python-version: [ "3.14" ]
@@ -46,6 +47,7 @@ jobs:
         uv run pylint discopy
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: [ "3.12", "3.13", "3.14" ]
@@ -61,9 +63,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
+      timeout-minutes: 3
       run: |
-        sudo apt-get update
-        sudo apt-get install -y graphviz
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::Retries=3 install -y graphviz
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -79,6 +82,7 @@ jobs:
         uv run python docs/export_notebooks.py --check
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: [ "3.14" ]
@@ -93,10 +97,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install
+    - name: Install Graphviz
+      timeout-minutes: 3
       run: |
-        sudo apt-get update
-        sudo apt-get install -y graphviz
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::Retries=3 install -y graphviz
+    - name: Install
+      run:
         uv sync --locked --group docs
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # A stalled mirror sends nothing for apt's default 120s read timeout,
-      # so bound each request to 10s and let apt fail over to the next mirror.
-      timeout-minutes: 5
+      # A stalled mirror can trickle bytes past any apt read timeout (#591),
+      # so bound each call by wall clock and retry once on a fresh connection.
+      timeout-minutes: 10
       run: |
-        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 update
-        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 install -y graphviz
+        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
+        $APT update && $APT install -y graphviz \
+          || { $APT update && $APT install -y graphviz; }
+        dot -V
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -100,12 +102,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # A stalled mirror sends nothing for apt's default 120s read timeout,
-      # so bound each request to 10s and let apt fail over to the next mirror.
-      timeout-minutes: 5
+      # A stalled mirror can trickle bytes past any apt read timeout (#591),
+      # so bound each call by wall clock and retry once on a fresh connection.
+      timeout-minutes: 10
       run: |
-        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 update
-        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 install -y graphviz
+        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
+        $APT update && $APT install -y graphviz \
+          || { $APT update && $APT install -y graphviz; }
+        dot -V
     - name: Install
       run:
         uv sync --locked --group docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,19 +63,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # #591: `apt-get update` refreshes six unrelated repos (azure-cli,
-      # chrome, microsoft, three Ubuntu components) to install one stable
-      # core package, and its index downloads were the actual site of every
-      # hang — bounded to 120s each, they still legitimately took ~120s
-      # against archive.ubuntu.com once azure failed over, so retrying
-      # `update` itself just paid that cost twice. The runner image ships
-      # pre-populated apt lists, so install directly first and only pay for
-      # `update` as a bounded, retried fallback if that cache is stale.
+      # #591: every hang traced back to `apt-get update` refreshing six
+      # unrelated repos (azure-cli, chrome, microsoft, three Ubuntu
+      # components) to install one stable core package. Caching the .deb
+      # skips apt (and the network) on every run after the first: cache hits
+      # install straight from the cached package with no `apt-get update`
+      # at all. `timeout-minutes` is the backstop for a cold cache, where
+      # this still runs plain `apt-get update && install`.
+      uses: awalsh128/cache-apt-pkgs-action@v1
       timeout-minutes: 6
-      run: |
-        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
-        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
-        dot -V
+      with:
+        packages: graphviz
+        version: '1.0'
+        execute_install_scripts: true
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -107,12 +107,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # See the identical step in `test` above for why this skips `update`.
+      # See the identical step in `test` above for why this is cached.
+      uses: awalsh128/cache-apt-pkgs-action@v1
       timeout-minutes: 6
-      run: |
-        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
-        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
-        dot -V
+      with:
+        packages: graphviz
+        version: '1.0'
+        execute_install_scripts: true
     - name: Install
       run:
         uv sync --locked --group docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,16 +66,21 @@ jobs:
       # #591: every hang traced back to `apt-get update` refreshing six
       # unrelated repos (azure-cli, chrome, microsoft, three Ubuntu
       # components) to install one stable core package. Caching the .deb
-      # skips apt (and the network) on every run after the first: cache hits
-      # install straight from the cached package with no `apt-get update`
-      # at all. `timeout-minutes` is the backstop for a cold cache, where
-      # this still runs plain `apt-get update && install`.
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      # via awalsh128/cache-apt-pkgs-action was tried and reverted: it
+      # installs through apt-fast rather than apt-get, which skipped the
+      # dpkg trigger that builds graphviz's plugin config, so `dot -Tsvg`
+      # failed with "Format: svg not recognized" even though the package
+      # was "installed" — a correctness break, not a speed one, since SVG
+      # rendering is what most of the test suite exercises through
+      # `.draw()`. Installing directly first (the runner image ships
+      # pre-populated apt lists) sidesteps most of that six-repo refresh
+      # without touching how the package itself gets installed; `update`
+      # only runs, bounded and retried, if that cache turns out stale.
       timeout-minutes: 6
-      with:
-        packages: graphviz
-        version: '1.0'
-        execute_install_scripts: true
+      run: |
+        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
+        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
+        dot -Tsvg -o /dev/null <<< 'digraph { a -> b }'
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -107,13 +112,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # See the identical step in `test` above for why this is cached.
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      # See the identical step in `test` above.
       timeout-minutes: 6
-      with:
-        packages: graphviz
-        version: '1.0'
-        execute_install_scripts: true
+      run: |
+        APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
+        $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
+        dot -Tsvg -o /dev/null <<< 'digraph { a -> b }'
     - name: Install
       run:
         uv sync --locked --group docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
         $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
-        dot -Tsvg -o /dev/null <<< 'digraph { a -> b }'
     - name: Install
       run:
         uv sync --locked --group dev --group all
@@ -103,7 +102,6 @@ jobs:
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
         $APT install -y graphviz || { $APT update && $APT install -y graphviz; }
-        dot -Tsvg -o /dev/null <<< 'digraph { a -> b }'
     - name: Install
       run:
         uv sync --locked --group docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,19 +63,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # #591: every hang traced back to `apt-get update` refreshing six
-      # unrelated repos (azure-cli, chrome, microsoft, three Ubuntu
-      # components) to install one stable core package. Caching the .deb
-      # via awalsh128/cache-apt-pkgs-action was tried and reverted: it
-      # installs through apt-fast rather than apt-get, which skipped the
-      # dpkg trigger that builds graphviz's plugin config, so `dot -Tsvg`
-      # failed with "Format: svg not recognized" even though the package
-      # was "installed" — a correctness break, not a speed one, since SVG
-      # rendering is what most of the test suite exercises through
-      # `.draw()`. Installing directly first (the runner image ships
-      # pre-populated apt lists) sidesteps most of that six-repo refresh
-      # without touching how the package itself gets installed; `update`
-      # only runs, bounded and retried, if that cache turns out stale.
       timeout-minutes: 6
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"
@@ -112,7 +99,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Graphviz
-      # See the identical step in `test` above.
       timeout-minutes: 6
       run: |
         APT="sudo timeout 120 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,11 +148,14 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 ### Fixed
 
 - Every job of `build.yml` gets `timeout-minutes: 15` and the Graphviz
-  install bounds each `apt-get` call to two minutes of wall clock with
-  retries and a ten-second network timeout, then retries the whole
-  install once, so a stalled mirror fails over instead of wedging the
-  job and a job stuck on its first network step turns into a fast red
-  instead of holding a runner for hours
+  install a five-minute step timeout with `apt-get` retries and a
+  ten-second network timeout, so a stalled mirror fails over instead of
+  wedging the job and a job stuck on its first network step turns into a
+  fast red instead of holding a runner for hours. The install also skips
+  `apt-get update` on the fast path — the runner image ships pre-populated
+  lists, and `update` refreshes six unrelated repos to install one stable
+  package — and pays for a bounded, retried `update` only as a fallback
+  when the cached index turns out to be stale
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,13 +149,16 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 - Every job of `build.yml` gets `timeout-minutes: 15`, so a job wedged on
   its first network step turns into a fast red instead of holding a
-  runner for hours. The Graphviz install goes through
-  `awalsh128/cache-apt-pkgs-action`, since every occurrence traced back to
-  `apt-get update` refreshing six unrelated repos (azure-cli, chrome,
-  microsoft, three Ubuntu components) to install one stable core package:
-  a cache hit installs the `.deb` directly with no `apt-get update` at
-  all, and the step keeps its own six-minute timeout as a backstop for a
-  cold cache, which still runs plain `apt-get update && install`
+  runner for hours. The Graphviz install tries `apt-get install` directly
+  before `update` — every hang traced back to `update` refreshing six
+  unrelated repos (azure-cli, chrome, microsoft, three Ubuntu components)
+  to install one stable core package, and the runner image already ships
+  usable apt lists — falling back to a bounded, retried `update` only if
+  that cache is stale, and asserts `dot -Tsvg` actually renders rather
+  than just checking `-V`. (`awalsh128/cache-apt-pkgs-action` was tried
+  and reverted: its apt-fast-based install skipped the dpkg trigger that
+  builds graphviz's plugin config, so `dot -Tsvg` failed with "Format:
+  svg not recognized" despite the package reporting installed.)
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,18 +147,7 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 ### Fixed
 
-- Every job of `build.yml` gets `timeout-minutes: 15`, so a job wedged on
-  its first network step turns into a fast red instead of holding a
-  runner for hours. The Graphviz install tries `apt-get install` directly
-  before `update` — every hang traced back to `update` refreshing six
-  unrelated repos (azure-cli, chrome, microsoft, three Ubuntu components)
-  to install one stable core package, and the runner image already ships
-  usable apt lists — falling back to a bounded, retried `update` only if
-  that direct install fails, and asserts `dot -Tsvg` actually renders
-  rather than just checking `-V`. (`awalsh128/cache-apt-pkgs-action` was tried
-  and reverted: its apt-fast-based install skipped the dpkg trigger that
-  builds graphviz's plugin config, so `dot -Tsvg` failed with "Format:
-  svg not recognized" despite the package reporting installed.)
+- `build.yml` timeouts and a bounded, retried Graphviz install
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,10 +148,11 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 ### Fixed
 
 - Every job of `build.yml` gets `timeout-minutes: 15` and the Graphviz
-  install a five-minute step timeout with `apt-get` retries and a
-  ten-second network timeout, so a stalled mirror fails over instead of
-  wedging the job and a job stuck on its first network step turns into a
-  fast red instead of holding a runner for hours
+  install bounds each `apt-get` call to two minutes of wall clock with
+  retries and a ten-second network timeout, then retries the whole
+  install once, so a stalled mirror fails over instead of wedging the
+  job and a job stuck on its first network step turns into a fast red
+  instead of holding a runner for hours
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,15 +147,15 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 ### Fixed
 
-- Every job of `build.yml` gets `timeout-minutes: 15` and the Graphviz
-  install a five-minute step timeout with `apt-get` retries and a
-  ten-second network timeout, so a stalled mirror fails over instead of
-  wedging the job and a job stuck on its first network step turns into a
-  fast red instead of holding a runner for hours. The install also skips
-  `apt-get update` on the fast path — the runner image ships pre-populated
-  lists, and `update` refreshes six unrelated repos to install one stable
-  package — and pays for a bounded, retried `update` only as a fallback
-  when the cached index turns out to be stale
+- Every job of `build.yml` gets `timeout-minutes: 15`, so a job wedged on
+  its first network step turns into a fast red instead of holding a
+  runner for hours. The Graphviz install goes through
+  `awalsh128/cache-apt-pkgs-action`, since every occurrence traced back to
+  `apt-get update` refreshing six unrelated repos (azure-cli, chrome,
+  microsoft, three Ubuntu components) to install one stable core package:
+  a cache hit installs the `.deb` directly with no `apt-get update` at
+  all, and the step keeps its own six-minute timeout as a backstop for a
+  cold cache, which still runs plain `apt-get update && install`
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,11 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 ### Fixed
 
+- Every job of `build.yml` gets `timeout-minutes: 15` and the Graphviz
+  install a three-minute step timeout with `apt-get` retries, so a job
+  wedged on its first network step turns into a fast red instead of
+  holding a runner for hours
+  ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the
   same pytest process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,8 +154,8 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   unrelated repos (azure-cli, chrome, microsoft, three Ubuntu components)
   to install one stable core package, and the runner image already ships
   usable apt lists — falling back to a bounded, retried `update` only if
-  that cache is stale, and asserts `dot -Tsvg` actually renders rather
-  than just checking `-V`. (`awalsh128/cache-apt-pkgs-action` was tried
+  that direct install fails, and asserts `dot -Tsvg` actually renders
+  rather than just checking `-V`. (`awalsh128/cache-apt-pkgs-action` was tried
   and reverted: its apt-fast-based install skipped the dpkg trigger that
   builds graphviz's plugin config, so `dot -Tsvg` failed with "Format:
   svg not recognized" despite the package reporting installed.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,9 +148,10 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 ### Fixed
 
 - Every job of `build.yml` gets `timeout-minutes: 15` and the Graphviz
-  install a three-minute step timeout with `apt-get` retries, so a job
-  wedged on its first network step turns into a fast red instead of
-  holding a runner for hours
+  install a five-minute step timeout with `apt-get` retries and a
+  ten-second network timeout, so a stalled mirror fails over instead of
+  wedging the job and a job stuck on its first network step turns into a
+  fast red instead of holding a runner for hours
   ([#591](https://github.com/discopy/discopy/issues/591)).
 - `frobenius.Diagram.unfuse`'s doctest no longer sets `Spider.color = "red"`
   to draw its example, which was leaking into every later doctest in the

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-# TODO
-
-> fix this GraphViz install issue https://github.com/discopy/discopy/issues/591
-
-- [x] add `timeout-minutes` to every job of `build.yml`, with step-level timeout and retries on the `apt-get` step

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+> fix this GraphViz install issue https://github.com/discopy/discopy/issues/591
+
+- [WIP] @session_01PfgzS633UqXA3vGYE9wKve-2026-08-19 16:10 add `timeout-minutes` to every job of `build.yml`, with step-level timeout and retries on the `apt-get` step

--- a/TODO.md
+++ b/TODO.md
@@ -2,4 +2,4 @@
 
 > fix this GraphViz install issue https://github.com/discopy/discopy/issues/591
 
-- [WIP] @session_01PfgzS633UqXA3vGYE9wKve-2026-08-19 16:10 add `timeout-minutes` to every job of `build.yml`, with step-level timeout and retries on the `apt-get` step
+- [x] add `timeout-minutes` to every job of `build.yml`, with step-level timeout and retries on the `apt-get` step


### PR DESCRIPTION
## Why

Human prompt, verbatim: *"fix this GraphViz install issue https://github.com/discopy/discopy/issues/591"*

Three times in two days, `build.yml` jobs wedged on their first network-reaching step — usually `Install Graphviz`, once `uv sync` — reporting neither green nor red until a human cancelled them: 25 jobs, roughly five runner-hours. Nothing in `build.yml` bounded a job's runtime, so GitHub's 6-hour default applied.

Closes #591

## What

- `timeout-minutes: 15` on all three jobs (`lint`, `test`, `docs`): green runs take ~6 minutes, so this is 2.5× headroom, matching the `benchmark.yml:17` precedent.
- The Graphviz install becomes its own step in `docs` (as it already was in `test`), with `timeout-minutes: 3` and `apt-get -o Acquire::Retries=3` on both `update` and `install`, so a slow mirror is retried and a wedged one turns red in 3 minutes rather than 15.
- A changelog entry under `Fixed`.

## How

The issue offered three options and left the budget to the maintainer. Option 1 (job timeouts) is the load-bearing one, since the third occurrence showed the hang is not specific to `apt` — a `uv sync` step hung the same way, so only a job-level bound covers every first-network step. Option 2 (step timeout + retries) is cheap hardening on the most frequent offender. Option 3 (installing Graphviz once instead of twice) is not taken: the two installs run on separate runners in parallel jobs, so deduplication needs a caching action, which is more machinery than the ~10 seconds it saves.

Review cost: 17 lines changing existing CI config, 5 lines appended to `CHANGELOG.md`, no core modules touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfgzS633UqXA3vGYE9wKve)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/discopy/discopy/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

