### PR TITLE
Make the style review robust to wide diffs and truncated gateway responses

### DIFF
--- a/.github/style-review/review.py
+++ b/.github/style-review/review.py
@@ -14,6 +14,7 @@ OpenAI-compatible gateway at ``BASE_URL`` and writes the findings to
 """
 
 import ast
+import http.client
 import json
 import os
 import re
@@ -143,18 +144,33 @@ def assemble(files, base_sha):
         files, budget, lambda path: changed_block(path, base_sha))
     context, budget, dropped = contents(deps, budget, context_block)
     parts = [instructions, style] + [block for _, block in context]
-    if dropped:
-        note = f"# Context dropped for size: {', '.join(dropped)}"
-        if len(note) + 2 <= budget:
+
+    def note_dropped(kind, paths):
+        nonlocal budget
+        note = f"# {kind} dropped for size: {', '.join(paths)}"
+        if paths and len(note) + 2 <= budget:
             parts.append(note)
             budget -= len(note) + 2
-    if missing:
-        note = f"# Changed files dropped for size: {', '.join(missing)}"
-        if len(note) + 2 <= budget:
-            parts.append(note)
-            budget -= len(note) + 2
+
+    note_dropped("Context", dropped)
+    note_dropped("Changed files", missing)
     parts += [block for _, block in changed]
     return "\n\n".join(parts)
+
+
+def complete(request, retries=2):
+    """The parsed completion, retrying a connection the gateway cut short
+    — a truncated chunked body raises ``IncompleteRead`` minutes into the
+    transfer, which is the network's failure, not the request's."""
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=600) as response:
+                return json.load(response)
+        except (http.client.IncompleteRead, TimeoutError) as error:
+            print(f"gateway cut the response short: {error!r}",
+                  file=sys.stderr)
+            if attempt == retries:
+                raise
 
 
 def ask(prompt):
@@ -170,8 +186,7 @@ def ask(prompt):
         "Authorization": f"Bearer {os.environ['API_KEY']}",
         "Content-Type": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=600) as response:
-            body = json.load(response)
+        body = complete(request)
     except urllib.error.HTTPError as error:
         text = error.read().decode(errors="replace")
         print(f"gateway error {error.code}: {text}", file=sys.stderr)

--- a/.github/style-review/review.py
+++ b/.github/style-review/review.py
@@ -141,12 +141,15 @@ def assemble(files, base_sha):
     budget = BUDGET + 2 - sum(len(part) + 2 for part in (instructions, style))
     changed, budget, missing = contents(
         files, budget, lambda path: changed_block(path, base_sha))
-    if missing:
-        raise ValueError(f"changed files past the budget: {missing}")
     context, budget, dropped = contents(deps, budget, context_block)
     parts = [instructions, style] + [block for _, block in context]
     if dropped:
         note = f"# Context dropped for size: {', '.join(dropped)}"
+        if len(note) + 2 <= budget:
+            parts.append(note)
+            budget -= len(note) + 2
+    if missing:
+        note = f"# Changed files dropped for size: {', '.join(missing)}"
         if len(note) + 2 <= budget:
             parts.append(note)
     parts += [block for _, block in changed]

--- a/.github/style-review/review.py
+++ b/.github/style-review/review.py
@@ -152,6 +152,7 @@ def assemble(files, base_sha):
         note = f"# Changed files dropped for size: {', '.join(missing)}"
         if len(note) + 2 <= budget:
             parts.append(note)
+            budget -= len(note) + 2
     parts += [block for _, block in changed]
     return "\n\n".join(parts)
 


### PR DESCRIPTION
## Why

Two crashes of the `review` check on real PRs, both in `.github/style-review/review.py`, both leaving the PR with no style review at all:

1. On #659 (39 changed files): `ValueError: changed files past the budget: [...]` — `assemble()` annotates each changed file with its *entire* new content (`-U100000`), so the changed-files section scales with the combined size of every touched file rather than the size of the edits, and any sufficiently wide PR blows the 400k-character `BUDGET` and aborts.
2. On #661 (7 changed files): `http.client.IncompleteRead` four minutes into reading the gateway's chunked response — the network cut the transfer short, and `ask()` had no retry.

## What

- Changed files that don't fit the budget now degrade the same way context (imported dependency) files already did: dropped with a `# Changed files dropped for size: ...` note, instead of raising. The note-adding logic is one `note_dropped` helper used for both kinds, and it decrements the remaining budget as it appends.
- `complete()` wraps the gateway request and retries a cut-short transfer (`IncompleteRead`, timeout) up to twice, logging each attempt, before giving up.

## How

Reused the existing dropped/note pattern rather than inventing a new one — the two cases (context vs. changed files not fitting) are the same shape, and treating them differently was the original bug. The retry lives in its own `complete()` function so `ask()`'s HTTP-error handling and answer parsing stay untouched. Verified with standalone harnesses: budget-exceeded assembly returns a prompt with the note instead of raising, and a mocked gateway that truncates twice then succeeds gets its answer through on the third attempt.

## Review cost

3 commits, 1 file changed, `.github/style-review/review.py` (~35 lines changed). No test file exists for this script (it's CI tooling outside the `discopy` package's `testpaths`); verified via `pflake8` (clean) and manual harnesses exercising both failure paths.