### PR TITLE
Add discopy.table, a set of diagrams as a table of cells over a union-find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 ### Added
 
+- Table representation, `discopy.table`, encoding a set of diagrams as a
+  `Carrier`: a table of cells over a union-find of wires, i.e. the carrier of
+  an e-graph. Each tree of the union-find is a vertex of the underlying
+  hypergraph, so merging two wires fuses two spiders and a vertex with more
+  than one producing cell holds alternatives, which a `Hypergraph` cannot
+  express: it reads the same incidence data as a Frobenius merge, and indeed
+  `(f + g).to_hypergraph()` raises today. `Carrier.from_diagram` interns a
+  diagram in one pass and `Morphism.to_diagram` reads back the cheapest
+  section, so the two are inverse up to the wiring laws. Ported from the
+  `metatheory` equality-saturation engine
+  ([#PR](https://github.com/discopy/discopy/pull/PR)).
 - A `workflows` job in `build.yml`, so that the code running our pull
   requests is checked like the code it checks: `actionlint` over the
   workflows, `pflake8` over `.github`, and `pytest .github/tests/*.py`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,30 @@
+# TODO
+
+> now we need to make a discopy PR as draft that contains the @../python/metatheory-refresh/ INITIAL data structure table in a module and a basic functor that can go back and forth from frobenius. /plan read in full the metatheory refresh repo, its docs and we design what to port properly, use /ponytail:ponytail when needed and we need to design a solid, tabular e-hypergraph data structure. one of the points should be that diagrams should and can be represented as tables. what would be the simplest, easiest solution ? the one that we have or others? evaluate all other different solutions and their pros and cons, then /mattpocock-skills:grilling and then we plan and execute the creation of a @discopy/ pull request off latest main.
+>
+> we don't want ECMap, but /mattpocock-skills:grilling properly on how to represent the table and what each feature of metatheory-refresh does and how do we get a basic initial version with roundtrip
+
+Design decisions taken in the session, for reviewers:
+
+* The store is the metatheory carrier: shards keyed `(op, n_in, n_out)` with
+  numpy `int64` columns, wires in a union-find, one hashcons per shard.
+* Arrows are boundary handles into a mutable store, as `Carrier`/`Morphism` are
+  in metatheory, not whole immutable values as `Hypergraph`/`CMap` are.
+* Spiders stay cells and lowering is a hand-written frame scan, both faithful to
+  `metatheory/functors/diagram_carrier.py`.
+* At the `MONOIDAL` point of metatheory's enrichment lattice: no absorption, no
+  `(sign, value)` labels on the union-find, no canonizers.
+* Each tree of the union-find is a vertex — the "meta-spider" whose legs are its
+  member wires. No `⊥` row and no node-kind column: metatheory's own
+  `docs/SEMANTICS.md` (branch `claude/semantics-md-review-ovxmpx`, commit
+  `1d90a812`) demotes Tiurin's ⊥ e-box to RESERVED, because the flat
+  nondeterministic join is already inductive in the union-find.
+
+- [ ] `discopy/table.py`: `SymbolTable`, `UnionFind`, `Shard`
+- [ ] `discopy/table.py`: `Carrier` (intern, hashcons, merge, rebuild, scan)
+- [ ] `discopy/table.py`: `Wires` and `Morphism`, the category structure
+- [ ] `discopy/table.py`: `Carrier.from_diagram`, the frame scan
+- [ ] `discopy/table.py`: `Morphism.to_diagram`, min-cost section then layout
+- [ ] `test/table.py` and the doctests
+- [ ] `discopy/__init__.py`, `docs/api/syntax.rst`, `CHANGELOG.md`
+- [ ] `pflake8`, `pylint`, `pytest`, coverage >= 98, sphinx

--- a/TODO.md
+++ b/TODO.md
@@ -20,11 +20,16 @@ Design decisions taken in the session, for reviewers:
   `1d90a812`) demotes Tiurin's ⊥ e-box to RESERVED, because the flat
   nondeterministic join is already inductive in the union-find.
 
-- [ ] `discopy/table.py`: `SymbolTable`, `UnionFind`, `Shard`
-- [ ] `discopy/table.py`: `Carrier` (intern, hashcons, merge, rebuild, scan)
-- [ ] `discopy/table.py`: `Wires` and `Morphism`, the category structure
-- [ ] `discopy/table.py`: `Carrier.from_diagram`, the frame scan
-- [ ] `discopy/table.py`: `Morphism.to_diagram`, min-cost section then layout
-- [ ] `test/table.py` and the doctests
-- [ ] `discopy/__init__.py`, `docs/api/syntax.rst`, `CHANGELOG.md`
-- [ ] `pflake8`, `pylint`, `pytest`, coverage >= 98, sphinx
+- [x] `discopy/table.py`: `SymbolTable`, `UnionFind`, `Shard`
+- [x] `discopy/table.py`: `Carrier` (intern, hashcons, merge, rebuild, scan)
+- [x] `discopy/table.py`: `Wires` and `Morphism`, the category structure
+- [x] `discopy/table.py`: `Carrier.from_diagram`, the frame scan
+- [x] `discopy/table.py`: `Morphism.to_diagram`, min-cost section then layout
+- [x] `test/table.py` and the doctests
+- [x] `discopy/__init__.py`, `docs/api/syntax.rst`, `CHANGELOG.md`
+- [x] `pflake8`, `pylint`, `pytest`, coverage >= 98, sphinx
+- [ ] Fill in the pull request number in the `CHANGELOG.md` entry
+
+Checks run locally: `pflake8 discopy` clean, `pylint discopy` 8.63/10,
+`pytest` 954 passed 1 skipped with every extra installed, `coverage` 98% in
+total and 100% on `discopy/table.py`, `sphinx-build` clean for the new pages.

--- a/discopy/__init__.py
+++ b/discopy/__init__.py
@@ -21,6 +21,7 @@ from discopy import (
     frobenius,
     hypergraph,
     cmap,
+    table,
     interaction,
     feedback,
     stream,

--- a/discopy/frobenius.py
+++ b/discopy/frobenius.py
@@ -63,7 +63,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from discopy import (
-    monoidal, rigid, markov, compact, pivotal, cmap, hypergraph)
+    monoidal, rigid, markov, compact, pivotal, cmap, hypergraph, table)
 from discopy.abc import HypergraphCategory
 from discopy.cat import factory
 from discopy.utils import assert_isatomic, deprecated_ob, factory_name
@@ -392,6 +392,7 @@ Diagram.swap_factory, Diagram.spider_factory = Swap, Spider
 Diagram.permutation_factory = Permutation
 Diagram.bubble_factory = Bubble
 Hypergraph = hypergraph.Hypergraph[Diagram]
+Carrier = table.Carrier[Diagram]
 Id = Diagram.id
 
 

--- a/discopy/table.py
+++ b/discopy/table.py
@@ -1,0 +1,723 @@
+# -*- coding: utf-8 -*-
+
+"""
+Diagrams as tables, i.e. the carrier of an e-graph of string diagrams.
+
+A :class:`Carrier` is a table of cells over a union-find of wires. A cell is
+one occurrence of a box: its row holds the wires on the box's input and
+output ports. Rows are sharded by generator and arity so that each
+:class:`Shard` is a rectangular table of integers.
+
+Each tree of the union-find is a vertex of the underlying hypergraph, i.e. the
+spider whose legs are its member wires. Thus :meth:`Carrier.merge` fuses two
+vertices and a vertex with more than one producing cell holds *alternatives*.
+This is what makes a carrier an e-graph rather than a
+:class:`discopy.hypergraph.Hypergraph`, which reads the same incidence data as
+a Frobenius merge and cannot hold a formal sum at all.
+
+Composition is a side effect on the carrier: :meth:`Morphism.then` asserts that
+the wires it composes are equal. Diagrams stay pure, the carrier is the
+effectful codomain of :meth:`Carrier.from_diagram`.
+
+Summary
+-------
+
+.. autosummary::
+    :template: class.rst
+    :nosignatures:
+    :toctree:
+
+    SymbolTable
+    UnionFind
+    Shard
+    Carrier
+    Wires
+    Morphism
+
+Example
+-------
+>>> from discopy.frobenius import Ty, Box, Carrier
+>>> x, y = Ty('x'), Ty('y')
+>>> f, g = Box('f', x, y), Box('g', y, x)
+>>> morphism = Carrier.from_diagram(f >> g)
+>>> print(morphism.to_diagram())
+f >> g
+
+Two occurrences of the same box on the same wires are one row, and merging two
+wires makes two rows congruent:
+
+>>> carrier = Carrier()
+>>> a, b = carrier.wires(x), carrier.wires(x)
+>>> u, v = carrier.intern(f, a.inside), carrier.intern(f, b.inside)
+>>> assert u != v and carrier.intern(f, a.inside) == u
+>>> carrier.merge(a.inside[0], b.inside[0])
+>>> carrier.rebuild()
+>>> assert carrier.uf.find(u[0]) == carrier.uf.find(v[0])
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Hashable, Iterator
+
+import numpy as np
+
+from discopy import hypergraph, messages
+from discopy.abc import MonoidalCategory, NamedGeneric
+from discopy.utils import AxiomError, classproperty, factory_name, unbiased
+
+if TYPE_CHECKING:
+    from discopy.monoidal import Box, Diagram, Ty
+
+
+def grow(column: np.ndarray, length: int) -> np.ndarray:
+    """
+    Copy a column into one at least twice as long, and at least ``length``.
+
+    Parameters:
+        column : The column to copy.
+        length : The number of rows the result must hold.
+
+    Example
+    -------
+    >>> grow(np.zeros(2, dtype=int), 3).shape
+    (4,)
+    """
+    capacity = max(2 * len(column), length, 1)
+    result = np.zeros((capacity, ) + column.shape[1:], dtype=column.dtype)
+    result[:len(column)] = column
+    return result
+
+
+class SymbolTable:
+    """
+    A table from hashable symbols to consecutive rows.
+
+    Symbols are keyed by type as well as value, so that ``1`` and ``True`` get
+    two different rows.
+
+    Parameters:
+        inside : The symbols to intern, in order.
+
+    Example
+    -------
+    >>> table = SymbolTable(["f"])
+    >>> table.intern("g"), table.intern("f"), table.intern(1), table.intern(1.)
+    (1, 0, 2, 3)
+    >>> table[1], len(table)
+    ('g', 4)
+    """
+    def __init__(self, inside: list[Hashable] = ()):
+        self.inside, self.index = [], {}
+        for symbol in inside:
+            self.intern(symbol)
+
+    def intern(self, symbol: Hashable) -> int:
+        """
+        The row of a symbol, appending it when it is not there yet.
+
+        Parameters:
+            symbol : The symbol to look up.
+        """
+        key = (type(symbol), symbol)
+        if key not in self.index:
+            self.index[key] = len(self.inside)
+            self.inside.append(symbol)
+        return self.index[key]
+
+    def __getitem__(self, row: int) -> Hashable:
+        return self.inside[row]
+
+    def __len__(self) -> int:
+        return len(self.inside)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, SymbolTable) and self.inside == other.inside
+
+    def __repr__(self) -> str:
+        return f"{factory_name(type(self))}({self.inside})"
+
+
+class UnionFind:
+    """
+    A union-find over wires, i.e. the vertices of a carrier.
+
+    Each tree is one vertex of the underlying hypergraph, the spider whose legs
+    are the wires in the tree. Roots are chosen by size, ties by lowest wire,
+    so that the table does not depend on the order of the merges.
+
+    Parameters:
+        parent : The parent of each wire, the identity for a fresh one.
+
+    Example
+    -------
+    >>> uf = UnionFind()
+    >>> a, b, c = uf.fresh(), uf.fresh(), uf.fresh()
+    >>> uf.union(b, c)
+    >>> uf.find(b), uf.find(c), uf.find(a)
+    (1, 1, 0)
+    >>> uf
+    table.UnionFind([0, 1, 1])
+    """
+    def __init__(self, parent: list[int] = ()):
+        parent = list(parent)
+        self.parent = np.array(parent + [0], dtype=np.int64)
+        self.size = np.ones(len(self.parent), dtype=np.int64)
+        self.length = len(parent)
+        for wire, root in enumerate(parent):
+            if wire != root:
+                self.union(wire, root)
+
+    def fresh(self) -> int:
+        """ Add a wire in a tree of its own and return it. """
+        if self.length == len(self.parent):
+            self.parent = grow(self.parent, self.length + 1)
+            self.size = grow(self.size, self.length + 1)
+        self.parent[self.length] = self.length
+        self.size[self.length] = 1
+        self.length += 1
+        return self.length - 1
+
+    def find(self, wire: int) -> int:
+        """
+        The root of the tree containing a wire, compressing the path to it.
+
+        Parameters:
+            wire : The wire to look up.
+        """
+        root = wire
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[wire] != root:
+            self.parent[wire], wire = root, self.parent[wire]
+        return int(root)
+
+    def union(self, left: int, right: int):
+        """
+        Merge the trees of two wires, i.e. fuse two vertices.
+
+        Parameters:
+            left : The first wire.
+            right : The second wire.
+        """
+        left, right = self.find(left), self.find(right)
+        if left == right:
+            return
+        if (self.size[left], -left) < (self.size[right], -right):
+            left, right = right, left
+        self.parent[right] = left
+        self.size[left] += self.size[right]
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, UnionFind) and list(self) == list(other)
+
+    def __iter__(self) -> Iterator[int]:
+        return (self.find(wire) for wire in range(self.length))
+
+    def __repr__(self) -> str:
+        return f"{factory_name(type(self))}({list(self)})"
+
+
+class Shard:
+    """
+    The rows of a carrier that share a generator and an arity.
+
+    Parameters:
+        n_in : The number of input ports of every row.
+        n_out : The number of output ports of every row.
+        rows : The wires of each row, inputs then outputs.
+
+    Example
+    -------
+    >>> shard = Shard(1, 2, [(0, 1, 2)])
+    >>> shard.append((3, 4, 5))
+    >>> shard.src.tolist(), shard.tgt.tolist()
+    ([[0], [3]], [[1, 2], [4, 5]])
+    >>> shard
+    table.Shard(1, 2, [(0, 1, 2), (3, 4, 5)])
+    """
+    def __init__(self, n_in: int, n_out: int,
+                 rows: list[tuple[int, ...]] = ()):
+        self.n_in, self.n_out, self.length = n_in, n_out, 0
+        self.columns = np.zeros((1, n_in + n_out), dtype=np.int64)
+        for row in rows:
+            self.append(row)
+
+    def append(self, row: tuple[int, ...]):
+        """
+        Add one row, growing the columns when they are full.
+
+        Parameters:
+            row : The wires of the row, inputs then outputs.
+        """
+        if len(row) != self.n_in + self.n_out:
+            raise ValueError
+        if self.length == len(self.columns):
+            self.columns = grow(self.columns, self.length + 1)
+        self.columns[self.length] = row
+        self.length += 1
+
+    @property
+    def src(self) -> np.ndarray:
+        """ The input columns of the rows. """
+        return self.columns[:self.length, :self.n_in]
+
+    @property
+    def tgt(self) -> np.ndarray:
+        """ The output columns of the rows. """
+        return self.columns[:self.length, self.n_in:]
+
+    def __getitem__(self, row: int) -> tuple[int, ...]:
+        return tuple(int(wire) for wire in self.columns[row])
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Shard) and (
+            self.n_in, self.n_out, list(self)) == (
+                other.n_in, other.n_out, list(other))
+
+    def __iter__(self) -> Iterator[tuple[int, ...]]:
+        return (self[row] for row in range(self.length))
+
+    def __repr__(self) -> str:
+        return factory_name(type(self))\
+            + f"({self.n_in}, {self.n_out}, {list(self)})"
+
+
+class Carrier(NamedGeneric['category']):
+    """
+    A table of cells over a union-find of wires.
+
+    Parameters:
+        wire_types : The type of each wire, in order.
+        cells : The box and the wires of each cell, inputs then outputs.
+        merges : The pairs of wires to merge once the cells are interned.
+
+    Example
+    -------
+    >>> from discopy.frobenius import Ty, Box, Carrier
+    >>> x = Ty('x')
+    >>> f = Box('f', x, x)
+    >>> carrier = Carrier([x, x], [(f, 0, 1)])
+    >>> assert carrier.cells == ((f, 0, 1), )
+    >>> assert carrier.shards[carrier.boxes.intern(f), 1, 1][0] == (0, 1)
+    """
+    category = None
+    ob = classproperty(lambda cls: cls.category.ob)
+
+    def __init__(self, wire_types: list[Ty] = (),
+                 cells: list[tuple] = (), merges: list[tuple] = ()):
+        self.boxes, self.uf = SymbolTable(), UnionFind()
+        self.shards, self.hashcons, self.rows = {}, {}, []
+        self.dead, self.wire_types = set(), []
+        for typ in wire_types:
+            self.wire(typ)
+        for box, *wires in cells:
+            self.append(box, tuple(wires[:len(box.dom)]),
+                        tuple(wires[len(box.dom):]))
+        for left, right in merges:
+            self.merge(left, right)
+
+    def wire(self, typ: Ty) -> int:
+        """
+        Add a wire of a given atomic type and return it.
+
+        Parameters:
+            typ : The type of the wire.
+        """
+        self.wire_types.append(typ)
+        return self.uf.fresh()
+
+    def wires(self, typ: Ty) -> Wires:
+        """
+        Add one wire for each object of a type and return them.
+
+        Parameters:
+            typ : The type of the wires.
+        """
+        return Wires(self, tuple(self.wire(obj) for obj in typ), typ)
+
+    def append(self, box: Box, src: tuple[int, ...],
+               tgt: tuple[int, ...]) -> int:
+        """
+        Add a cell with given input and output wires, and return its row.
+
+        Parameters:
+            box : The box of the cell.
+            src : The wires on the input ports.
+            tgt : The wires on the output ports.
+        """
+        key = (self.boxes.intern(box), len(box.dom), len(box.cod))
+        shard = self.shards.setdefault(key, Shard(key[1], key[2]))
+        shard.append(tuple(src) + tuple(tgt))
+        self.rows.append((key, len(shard) - 1))
+        self.hashcons[key, tuple(map(self.uf.find, src))] = len(self.rows) - 1
+        return len(self.rows) - 1
+
+    def intern(self, box: Box, src: tuple[int, ...]) -> tuple[int, ...]:
+        """
+        The output wires of a box on given input wires, adding a cell for it
+        when there is not one already, i.e. hash-consing.
+
+        Parameters:
+            box : The box to intern.
+            src : The wires on its input ports.
+        """
+        key = (self.boxes.intern(box), len(box.dom), len(box.cod))
+        canon = tuple(map(self.uf.find, src))
+        if (key, canon) in self.hashcons:
+            return self[self.hashcons[key, canon]][2]
+        tgt = tuple(self.wire(obj) for obj in box.cod)
+        self.append(box, tuple(src), tgt)
+        return tgt
+
+    def merge(self, left: int, right: int):
+        """
+        Assert that two wires are equal, i.e. fuse their vertices.
+
+        Parameters:
+            left : The first wire.
+            right : The second wire.
+        """
+        self.uf.union(left, right)
+
+    def rebuild(self):
+        """
+        Close the carrier under congruence: when two live cells have the same
+        box on the same input classes, their output wires get merged and the
+        later cell is marked dead.
+        """
+        while True:
+            index, stable = {}, True
+            for gid, box, src, tgt in self.scan():
+                key = (box, tuple(map(self.uf.find, src)))
+                if index.setdefault(key, gid) == gid:
+                    continue
+                for left, right in zip(self[index[key]][2], tgt):
+                    self.uf.union(left, right)
+                self.dead.add(gid)
+                stable = False
+            if stable:
+                break
+        self.hashcons = {
+            (self.rows[gid][0], tuple(map(self.uf.find, src))): gid
+            for gid, box, src, tgt in self.scan()}
+
+    def scan(self) -> Iterator[tuple[int, Box, tuple, tuple]]:
+        """ The live cells in order, as a row with its box and its wires. """
+        return ((gid, ) + self[gid] for gid in range(len(self.rows))
+                if gid not in self.dead)
+
+    @property
+    def cells(self) -> tuple[tuple, ...]:
+        """ The box and the wires of each cell, live or dead. """
+        return tuple((box, ) + src + tgt for box, src, tgt in map(
+            self.__getitem__, range(len(self.rows))))
+
+    def costs(self) -> tuple[dict[int, int], dict[int, int]]:
+        """
+        The least number of cells needed to produce each vertex, and the
+        cheapest cell producing it, breaking ties by lowest row.
+        """
+        produced = {
+            wire for _, _, _, tgt in self.scan() for wire in map(
+                self.uf.find, tgt)}
+        cost = {wire: 0 for wire in set(self.uf) if wire not in produced}
+        chosen = {}
+        for _ in range(len(self.rows) + 1):
+            stable = True
+            for gid, box, src, tgt in self.scan():
+                if any(self.uf.find(wire) not in cost for wire in src):
+                    continue
+                weight = 1 + sum(cost[self.uf.find(w)] for w in src)
+                for wire in map(self.uf.find, tgt):
+                    if wire not in cost or weight < cost[wire]:
+                        cost[wire], chosen[wire] = weight, gid
+                        stable = False
+            if stable:
+                break
+        return cost, chosen
+
+    def section(self, boundary: tuple[int, ...]) -> list[int]:
+        """
+        The cheapest cells that produce a given boundary, i.e. one alternative
+        per vertex, together with the cells that produce nothing.
+
+        Parameters:
+            boundary : The wires the section has to produce.
+        """
+        chosen, keep, scan = self.costs()[1], set(), list(boundary)
+        for gid, box, src, tgt in self.scan():
+            if not tgt:
+                keep.add(gid)
+                scan += list(src)
+        while scan:
+            gid = chosen.get(self.uf.find(scan.pop()))
+            if gid is None or gid in keep:
+                continue
+            keep.add(gid)
+            scan += list(self[gid][1])
+        return sorted(keep)
+
+    def from_box(self, box: Box) -> Morphism:
+        """
+        The morphism of a box on fresh input wires.
+
+        Parameters:
+            box : The box to intern.
+        """
+        dom = self.wires(box.dom)
+        cod = Wires(self, self.intern(box, dom.inside), box.cod)
+        return Morphism(dom, cod)
+
+    @classmethod
+    def from_diagram(cls, diagram: Diagram) -> Morphism:
+        """
+        Intern a diagram into a fresh carrier, one cell for each box.
+
+        Parameters:
+            diagram : The diagram to intern.
+
+        Example
+        -------
+        >>> from discopy.frobenius import Ty, Box, Carrier
+        >>> x = Ty('x')
+        >>> f = Box('f', x, x)
+        >>> carrier = Carrier.from_diagram(f >> f).carrier
+        >>> len(carrier.rows), len(carrier.uf)
+        (2, 3)
+        """
+        factory = cls if cls.category else cls[type(diagram).ar]
+        carrier = factory()
+        dom = carrier.wires(diagram.dom)
+        scan = list(dom.inside)
+        for box, offset in zip(diagram.boxes, diagram.offsets):
+            scan[offset:offset + len(box.dom)] = carrier.intern(
+                box, tuple(scan[offset:offset + len(box.dom)]))
+        return Morphism(dom, Wires(carrier, tuple(scan), diagram.cod))
+
+    def __getitem__(self, gid: int) -> tuple[Box, tuple, tuple]:
+        key, row = self.rows[gid]
+        wires = self.shards[key][row]
+        return self.boxes[key[0]], wires[:key[1]], wires[key[1]:]
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Carrier) and (
+            self.category, self.wire_types, self.cells, self.uf) == (
+                other.category, other.wire_types, other.cells, other.uf)
+
+    def __repr__(self) -> str:
+        merges = [(wire, root) for wire, root in enumerate(self.uf)
+                  if wire != root]
+        return factory_name(type(self))\
+            + f"({self.wire_types}, {list(self.cells)}, {merges})"
+
+
+@dataclass(frozen=True, eq=False)
+class Wires:
+    """
+    The wires on the boundary of a :class:`Morphism`, i.e. an object of the
+    category presented by a carrier.
+
+    Parameters:
+        carrier : The carrier holding the wires.
+        inside : The wires themselves.
+        ty : The type they carry.
+
+    Example
+    -------
+    >>> from discopy.frobenius import Ty, Carrier
+    >>> x, y = Ty('x'), Ty('y')
+    >>> carrier = Carrier()
+    >>> assert (carrier.wires(x) @ carrier.wires(y)).ty == x @ y
+    """
+    carrier: Carrier
+    inside: tuple[int, ...]
+    ty: Ty
+
+    @unbiased
+    def tensor(self, other: Wires) -> Wires:
+        """
+        Juxtapose the wires of two objects.
+
+        Parameters:
+            other : The other object.
+        """
+        if self.carrier is not other.carrier:
+            raise AxiomError(messages.TYPE_ERROR.format(
+                self.carrier, other.carrier))
+        return Wires(
+            self.carrier, self.inside + other.inside, self.ty @ other.ty)
+
+    __matmul__ = tensor
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Wires) and self.carrier is other.carrier\
+            and (self.inside, self.ty) == (other.inside, other.ty)
+
+    def __len__(self) -> int:
+        return len(self.inside)
+
+
+class Morphism(MonoidalCategory):
+    """
+    An arrow of the category presented by a carrier, i.e. a pair of boundaries.
+
+    Composition asserts that the wires it composes are equal, so the laws of a
+    monoidal category hold up to :meth:`equiv` rather than on the nose.
+
+    Parameters:
+        dom : The wires on the domain.
+        cod : The wires on the codomain.
+
+    Example
+    -------
+    >>> from discopy.frobenius import Ty, Box, Carrier
+    >>> x = Ty('x')
+    >>> f, g = Box('f', x, x), Box('g', x, x)
+    >>> carrier = Carrier()
+    >>> u, v = map(carrier.from_box, (f, g))
+    >>> assert (u >> v).dom == u.dom and (u >> v).cod == v.cod
+    >>> assert Morphism.id(u.dom).then(u).equiv(u)
+    """
+    ob = Wires
+
+    def __init__(self, dom: Wires, cod: Wires):
+        self.dom, self.cod = dom, cod
+
+    @property
+    def carrier(self) -> Carrier:
+        """ The carrier this morphism is a boundary of. """
+        return self.dom.carrier
+
+    @classmethod
+    def id(cls, dom: Wires) -> Morphism:
+        """
+        The identity on an object, i.e. the same wires twice.
+
+        Parameters:
+            dom : The object.
+        """
+        return cls(dom, dom)
+
+    def is_composable(self, other: Morphism) -> bool:
+        return self.carrier is other.carrier and self.cod.ty == other.dom.ty
+
+    @unbiased
+    def then(self, other: Morphism) -> Morphism:
+        """
+        Compose two morphisms by merging the wires on their shared boundary.
+
+        Parameters:
+            other : The other morphism.
+        """
+        if not self.is_composable(other):
+            raise AxiomError(messages.NOT_COMPOSABLE.format(
+                self, other, self.cod.ty, other.dom.ty))
+        for left, right in zip(self.cod.inside, other.dom.inside):
+            self.carrier.merge(left, right)
+        return Morphism(self.dom, other.cod)
+
+    @unbiased
+    def tensor(self, other: Morphism) -> Morphism:
+        """
+        Juxtapose two morphisms.
+
+        Parameters:
+            other : The other morphism.
+        """
+        return Morphism(self.dom @ other.dom, self.cod @ other.cod)
+
+    def equiv(self, other: Morphism) -> bool:
+        """
+        Whether two morphisms have the same boundary up to the equations
+        asserted in the carrier.
+
+        Parameters:
+            other : The other morphism.
+        """
+        find = self.carrier.uf.find
+        return self.carrier is other.carrier and all(
+            len(x) == len(y) and all(map(
+                lambda i, j: find(i) == find(j), x.inside, y.inside))
+            for x, y in [(self.dom, other.dom), (self.cod, other.cod)])
+
+    def to_hypergraph(self) -> hypergraph.Hypergraph:
+        """
+        The hypergraph of the cheapest section of the carrier producing this
+        morphism, i.e. one alternative for each vertex.
+
+        A cell with no inputs is copied once for each of the ports that
+        consume it, so that hash-consing two occurrences of the same state
+        does not turn them into one.
+
+        Example
+        -------
+        >>> from discopy.frobenius import Ty, Box, Carrier
+        >>> x = Ty('x')
+        >>> f, s = Box('f', x, x), Box('s', Ty(), x)
+        >>> assert Carrier.from_diagram(f).to_hypergraph()\\
+        ...     == f.to_hypergraph()
+        >>> assert len(Carrier.from_diagram(s @ s).to_hypergraph().boxes) == 2
+        """
+        carrier, labels, spider_types = self.carrier, {}, {}
+
+        def label(wire):
+            root = carrier.uf.find(wire)
+            if root not in labels:
+                labels[root] = len(spider_types)
+                spider_types[labels[root]] = carrier.wire_types[root]
+            return labels[root]
+
+        section = carrier.section(self.cod.inside)
+        dom_wires = tuple(map(label, self.dom.inside))
+        boxes = [carrier[gid][0] for gid in section]
+        box_wires = [(tuple(map(label, carrier[gid][1])),
+                      tuple(map(label, carrier[gid][2]))) for gid in section]
+        states = {cod[0]: i for i, (dom, cod) in enumerate(box_wires)
+                  if not dom and len(cod) == 1}
+        occupied = set()
+
+        def consume(spider):
+            if spider not in occupied or spider not in states:
+                occupied.add(spider)
+                return spider
+            spider_types[len(spider_types)] = spider_types[spider]
+            boxes.append(boxes[states[spider]])
+            box_wires.append(((), (len(spider_types) - 1, )))
+            return len(spider_types) - 1
+
+        for i in range(len(section)):
+            box_wires[i] = (
+                tuple(map(consume, box_wires[i][0])), box_wires[i][1])
+        cod_wires = tuple(map(consume, map(label, self.cod.inside)))
+        factory = hypergraph.Hypergraph[type(carrier).category]
+        return factory(self.dom.ty, self.cod.ty, tuple(boxes),
+                       (dom_wires, tuple(box_wires), cod_wires), spider_types)
+
+    def to_diagram(self) -> Diagram:
+        """
+        The diagram of the cheapest section of the carrier producing this
+        morphism, see :meth:`to_hypergraph`.
+
+        Example
+        -------
+        >>> from discopy.frobenius import Ty, Box, Carrier
+        >>> x, y = Ty('x'), Ty('y')
+        >>> f, g = Box('f', x, y), Box('g', x, y)
+        >>> print(Carrier.from_diagram(f @ g).to_diagram())
+        f @ g
+        """
+        return self.to_hypergraph().to_diagram()
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Morphism)\
+            and (self.dom, self.cod) == (other.dom, other.cod)
+
+    def __repr__(self) -> str:
+        return f"{factory_name(type(self))}({self.dom}, {self.cod})"

--- a/docs/api/syntax.rst
+++ b/docs/api/syntax.rst
@@ -25,3 +25,4 @@ DisCoPy's mathematical core: a zoo of diagrams, categories and functors.
     discopy.frobenius
     discopy.hypergraph
     discopy.cmap
+    discopy.table

--- a/test/table.py
+++ b/test/table.py
@@ -1,0 +1,145 @@
+import numpy as np
+from pytest import mark, raises
+
+from discopy import frobenius, table
+from discopy.frobenius import (
+    Box, Cap, Carrier, Cup, Diagram, Id, Spider, Swap, Ty)
+from discopy.table import Morphism, Shard, SymbolTable, UnionFind, Wires
+from discopy.utils import AxiomError
+
+x, y = Ty('x'), Ty('y')
+f, g, h = Box('f', x, y), Box('g', y, x), Box('h', x, x)
+state = Box('s', Ty(), x)
+
+
+def test_grow():
+    assert table.grow(np.zeros(0, dtype=int), 1).shape == (1, )
+    assert table.grow(np.zeros((2, 3), dtype=int), 3).shape == (4, 3)
+
+
+def test_SymbolTable():
+    symbols = SymbolTable([1])
+    assert symbols.intern(True) == 1 != symbols.intern(1)
+    assert symbols[0] == 1 and len(symbols) == 2
+    assert symbols == eval(repr(symbols)) != SymbolTable()
+
+
+def test_UnionFind():
+    union_find = UnionFind()
+    a, b, c = [union_find.fresh() for _ in range(3)]
+    union_find.union(b, c)
+    union_find.union(c, b)
+    assert union_find.find(c) == union_find.find(b) == b
+    assert union_find.find(a) == a and len(union_find) == 3
+    assert union_find == eval(repr(union_find)) != UnionFind()
+
+
+def test_UnionFind_by_size():
+    union_find = UnionFind()
+    a, b, c = [union_find.fresh() for _ in range(3)]
+    union_find.union(b, c)
+    union_find.union(a, b)
+    assert union_find.find(a) == b
+
+
+def test_UnionFind_path_compression():
+    union_find = UnionFind()
+    for _ in range(4):
+        union_find.fresh()
+    union_find.union(0, 1)
+    union_find.union(2, 3)
+    union_find.union(1, 3)
+    assert union_find.find(3) == 0 and union_find.parent[3] == 0
+
+
+def test_Shard():
+    shard = Shard(1, 1, [(0, 1)])
+    for row in [(2, 3), (4, 5)]:
+        shard.append(row)
+    assert list(shard) == [(0, 1), (2, 3), (4, 5)] and len(shard) == 3
+    assert shard.src.tolist() == [[0], [2], [4]]
+    assert shard.tgt.tolist() == [[1], [3], [5]]
+    assert shard == eval(repr(shard)) != Shard(1, 1)
+    with raises(ValueError):
+        shard.append((0, 1, 2))
+
+
+def test_Carrier_repr():
+    carrier = Carrier([x, x], [(f, 0, 1)], [(0, 1)])
+    assert carrier == eval(repr(carrier)) != Carrier()
+    assert carrier.cells == ((f, 0, 1), )
+
+
+def test_Carrier_intern():
+    carrier = Carrier()
+    a = carrier.wires(x)
+    assert carrier.intern(f, a.inside) == carrier.intern(f, a.inside)
+    assert len(carrier.rows) == 1
+    assert carrier.intern(h, a.inside) != carrier.intern(f, a.inside)
+
+
+def test_Carrier_rebuild():
+    carrier = Carrier()
+    a, b = carrier.wires(x), carrier.wires(x)
+    u, v = carrier.intern(f, a.inside), carrier.intern(f, b.inside)
+    assert carrier.uf.find(u[0]) != carrier.uf.find(v[0])
+    carrier.merge(a.inside[0], b.inside[0])
+    carrier.rebuild()
+    assert carrier.uf.find(u[0]) == carrier.uf.find(v[0])
+    assert len(carrier.dead) == 1
+    assert list(carrier.scan())[0][0] == 0
+
+
+def test_Wires():
+    carrier = Carrier()
+    a, b = carrier.wires(x), carrier.wires(y)
+    assert (a @ b).ty == x @ y and len(a @ b) == 2
+    assert a != b and a == Wires(carrier, a.inside, x)
+    assert a != Wires(Carrier(), a.inside, x) and a != a.inside
+    with raises(AxiomError):
+        a @ Carrier().wires(x)
+
+
+def test_Morphism_laws():
+    carrier = Carrier()
+    u, v, w = map(carrier.from_box, (f, g, h))
+    assert Morphism.id(u.dom).then(u).equiv(u)
+    assert u.then(Morphism.id(u.cod)).equiv(u)
+    assert u.then(v).then(w).equiv(u.then(v.then(w)))
+    assert (u @ v).equiv(Morphism(u.dom @ v.dom, u.cod @ v.cod))
+    assert not u.equiv(v) and not u.equiv(Carrier().from_box(f))
+    assert u == Morphism(u.dom, u.cod) != v and u != u.dom
+    with raises(AxiomError):
+        u.then(u)
+
+
+def test_Morphism_extraction():
+    carrier = Carrier()
+    a = carrier.wires(x)
+    cheap = carrier.intern(f, a.inside)
+    costly = carrier.intern(f, carrier.intern(g, carrier.intern(f, a.inside)))
+    carrier.merge(cheap[0], costly[0])
+    carrier.rebuild()
+    morphism = Morphism(a, Wires(carrier, cheap, y))
+    assert morphism.to_diagram() == f
+
+
+def test_Carrier_costs_cycle():
+    carrier = Carrier()
+    a = carrier.wires(x)
+    carrier.merge(a.inside[0], carrier.intern(h, a.inside)[0])
+    assert carrier.costs() == ({}, {})
+
+
+@mark.parametrize("diagram", [
+    f, f >> g, f @ g, Id(x), Swap(x, y), Cap(x, x) >> Cup(x, x),
+    Id(x) @ Cap(x, x) >> Cup(x, x) @ Id(x), Spider(2, 1, x),
+    Spider(1, 1, x, .5), Spider(0, 0, x), state @ state, state >> f,
+    f @ Id(x) >> Id(y) @ h])
+def test_round_trip(diagram):
+    morphism = Carrier.from_diagram(diagram)
+    assert morphism.to_diagram().to_hypergraph() == diagram.to_hypergraph()
+
+
+def test_from_diagram_generic():
+    assert table.Carrier.from_diagram(f).carrier.category == frobenius.Diagram


### PR DESCRIPTION
## Why

Human prompt, verbatim:

> now we need to make a discopy PR as draft that contains the @../python/metatheory-refresh/ INITIAL data structure table in a module and a basic functor that can go back and forth from frobenius. [...] we need to design a solid, tabular e-hypergraph data structure. one of the points should be that diagrams should and can be represented as tables. what would be the simplest, easiest solution ? the one that we have or others? evaluate all other different solutions and their pros and cons [...] and then we plan and execute the creation of a @discopy/ pull request off latest main.
>
> we don't want ECMap, but [grill] properly on how to represent the table and what each feature of metatheory-refresh does and how do we get a basic initial version with roundtrip

The data structure comes from `metatheory`, an equality-saturation engine for
string diagrams whose core is a *carrier*: a table of cells over a union-find
of wires. This is the first step of porting it, and it fills a gap that stands
on its own in DisCoPy: a `Hypergraph` cannot hold alternatives. Today

```python
>>> (f + g).to_hypergraph()
AttributeError: type object 'Hypergraph[Diagram]' has no attribute 'zero'
```

and worse, the same incidence data has two incompatible readings:
`Hypergraph.to_diagram` sends a vertex with several producers through
`make_monogamous`, i.e. it reads it as a Frobenius *merge*, where an e-graph
reads it as a *join* of alternatives. Those two readings cannot share a class,
which is why the carrier is its own category rather than a `Hypergraph`
subclass. It is the same enrichment in commutative monoids as #570, seen on the
hypergraph side, and the structure #26 and #314 would eventually want.

## What

A new module `discopy.table` with six classes, bound as `frobenius.Carrier`.

* `SymbolTable`, a dense interner from hashable symbols to rows.
* `UnionFind` over wires, with roots chosen by size and ties by lowest wire so
  that the table does not depend on the order of the merges.
* `Shard`, the rows sharing a generator and an arity, as `numpy` columns.
* `Carrier`, the table itself: `intern` (hash-consing), `merge`, `rebuild`
  (congruence closure), `scan`, `costs` and `section` (the cheapest choice of
  one alternative per vertex), `from_box` and `from_diagram`.
* `Wires`, an object of the category presented by a carrier, and `Morphism`,
  an arrow, i.e. a pair of boundaries, implementing `abc.MonoidalCategory`
  together with `equiv`, `to_hypergraph` and `to_diagram`.

The mathematical content is that **each tree of the union-find is a vertex of
the underlying hypergraph**, the spider whose legs are its member wires. So
`Carrier.merge` fuses two spiders, and a vertex with more than one producing
cell holds alternatives. That is the whole difference from `Hypergraph`, and it
needs no extra kind of row: it is the reading of the union-find.

`Carrier.from_diagram` interns a diagram in one pass, one cell per box, and
`Morphism.to_diagram` reads back the cheapest section, so the two are inverse
up to the wiring laws of the level:

```python
>>> morphism = Carrier.from_diagram(diagram)
>>> assert morphism.to_diagram().to_hypergraph() == diagram.to_hypergraph()
```

`test_round_trip` asserts this for a box, a composition, a tensor, an identity,
a swap, a cup-cap pair, a snake, a spider phased and phaseless, a scalar
spider, a repeated state and a wide layer.

## How

Faithful to `metatheory` where it has made a decision, and deliberately at the
simplest point of its enrichment lattice.

* **Storage** is `metatheory`'s: shards keyed by generator and arity with
  `numpy` `int64` columns, wires in a union-find, one hash-cons per shard.
  `numpy` is already a hard dependency.
* **Arrows are boundary handles into a mutable store**, as `Carrier` and
  `Morphism` are there, not whole immutable values as `Hypergraph` and `CMap`
  are. Composition is a side effect, so the laws hold up to `Morphism.equiv`
  rather than on the nose. This is the case STYLE.md blesses: diagrams stay
  pure, and the carrier is the effectful codomain of `from_diagram`.
* **Spiders stay cells** and lowering is a hand-written scan over
  `zip(boxes, offsets)`, both as `metatheory`'s `diagram_carrier.lower` does.
  At its `MONOIDAL` enrichment there is no absorption at all, no `(sign,
  value)` labels on the union-find and no canonizers, so every box is a cell
  and the union-find is plain.
* **Extraction** is `metatheory`'s: a bottom-up relaxation choosing the cell
  producing each vertex at least cost, ties by lowest row, then its monogamy
  lift — a cell with no inputs is copied once per port that consumes it, so
  that hash-consing two occurrences of the same state does not turn them into
  one. Layout is left to `Hypergraph.to_diagram`, which already owns it.

Deviations from `metatheory`, each reversible:

1. The hash-cons is a `dict` per shard rather than its `numba` open-addressing
   table, which is semantically empty; `numba` is not a dependency here.
2. `find` returns a wire rather than a triple: at this point of the lattice the
   two label columns are constant. They are the extension point.
3. No `sign` column on cells; it is allocated but never read there either.
4. A cell is keyed by its `Box`, not by the type-erased head `("gen", class,
   phase, is_dagger, z)`. That erasure exists so a rule pattern can match a
   concrete instance; there is no matcher here, and erasing would make the
   round trip lossy.
5. One inline cost rather than the quantale interface, which has three
   implementations there and one use here.

Out of scope, i.e. what makes this the *initial* data structure: rules and
theories as higher rows, e-matching, saturation, proofs, the canonizers, and
every absorption flag. Also out of scope is Tiurin's `⊥` e-box: `metatheory`'s
own `docs/SEMANTICS.md` demotes it to reserved for joins nested inside a
functorial box, because the flat join is already inductive in the union-find.

Checks: `pflake8 discopy` clean, `pylint discopy` 8.63/10, `pytest` 954 passed
and 1 skipped with every extra installed, `coverage` 98% in total and 100% on
`discopy/table.py`, `sphinx-build` with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/discopy/discopy/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

