### PR TITLE
Make every then take (self, *others), n-ary where the fold costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,10 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   rather than returning `self`, so
   `Tensor([1, 0, 0, 1], Dim(2), Dim(2)).then(None)` raised `TypeError`
   ([#760](https://github.com/discopy/discopy/issues/760)).
+  Six of them take `utils.unbiased`, which already spells the signature;
+  the two `python.finset` ones are written out instead, because the
+  wrapper costs more than the call it wraps there -- composing two finite
+  functions is cheap enough that the extra frame was 29% of it.
   `utils.MappingOrCallable.then` is binary too and stays that way:
   it post-composes a mapping with a functor rather than composing two
   morphisms, and `MappingOrCallable` is not an `abc.Category`.
@@ -504,6 +508,15 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   inherited by `python.multiplicative.Function` and
   `python.additive.Function`; a chain built with `>>` still nests, since
   that operator is binary.
+
+### Performance
+
+- `python.finset.Permutation.then` walks each index through the
+  permutations in one pass over their `inside` lists, rather than reading
+  both operands through `__getitem__` at every element and iterating the
+  first through the `Sequence` protocol: composing two permutations of
+  five elements takes 5.6 us rather than 7.6, and `Permutation.conjugate`,
+  which composes twice, 19.5 us rather than 23.2.
 
 - The marimo notebook previews in the docs follow the theme switch. The
   notebooks are exported with marimo's `system` theme and the docs relay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,23 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
 
 ### Changed
 
+- Every `then` takes `(self, *others)`, the signature that
+  `abc.Category.then` declares and `cat.Arrow` implements. Eight classes
+  kept one of two non-conforming shapes: `(self, other=None, *others)` on
+  `tensor.Tensor` and `quantum.channel.Channel`, and a plain binary
+  `(self, other)` with no `utils.unbiased` on `cat.Functor`,
+  `cat.Transformation`, `monoidal.Functor`, `python.function.Function`,
+  `python.finset.Function` and `python.finset.Permutation`, which raised
+  `TypeError` on a third argument.
+  The `None` branch was dead rather than a unit: it forwarded to
+  `cat.Arrow.then` as `super().then(None)`, which composes against `None`
+  rather than returning `self`, so
+  `Tensor([1, 0, 0, 1], Dim(2), Dim(2)).then(None)` raised `TypeError`
+  ([#760](https://github.com/discopy/discopy/issues/760)).
+  `utils.MappingOrCallable.then` is binary too and stays that way:
+  it post-composes a mapping with a functor rather than composing two
+  morphisms, and `MappingOrCallable` is not an `abc.Category`.
+
 - `monoidal.Colour` is transparent by default rather than white, i.e. its
   `name` defaults to the new `config.TRANSPARENT` and `monoidal.white` is
   renamed to `monoidal.transparent`. The drawing code painted every region
@@ -477,6 +494,16 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   reviewer first.
 
 ### Fixed
+
+- `python.function.Function.then` composes its `n` functions in one Python
+  frame rather than nesting one closure per composition, so that a long
+  chain can be called at all: composing two thousand functions and calling
+  the result raised `RecursionError`, the same nesting that made the tensor
+  of a few hundred `python` functions raise
+  ([#760](https://github.com/discopy/discopy/issues/760)). This is
+  inherited by `python.multiplicative.Function` and
+  `python.additive.Function`; a chain built with `>>` still nests, since
+  that operator is binary.
 
 - The marimo notebook previews in the docs follow the theme switch. The
   notebooks are exported with marimo's `system` theme and the docs relay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -509,15 +509,6 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   `python.additive.Function`; a chain built with `>>` still nests, since
   that operator is binary.
 
-### Performance
-
-- `python.finset.Permutation.then` walks each index through the
-  permutations in one pass over their `inside` lists, rather than reading
-  both operands through `__getitem__` at every element and iterating the
-  first through the `Sequence` protocol: composing two permutations of
-  five elements takes 5.6 us rather than 7.6, and `Permutation.conjugate`,
-  which composes twice, 19.5 us rather than 23.2.
-
 - The marimo notebook previews in the docs follow the theme switch. The
   notebooks are exported with marimo's `system` theme and the docs relay
   the resolved theme into each notebook's iframe through marimo's
@@ -674,6 +665,13 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   ([#484](https://github.com/discopy/discopy/pull/484)).
 
 ### Performance
+
+- `python.finset.Permutation.then` walks each index through the
+  permutations in one pass over their `inside` lists, rather than reading
+  both operands through `__getitem__` at every element and iterating the
+  first through the `Sequence` protocol: composing two permutations of
+  five elements takes 5.6 us rather than 7.6, and `Permutation.conjugate`,
+  which composes twice, 19.5 us rather than 23.2.
 
 - The elements of a Hopf algebra (`drinfeld_element`, `pivotal_element`,
   `ribbon_element`) contract each structural generator once through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,10 +188,12 @@ Changes since [`1.2.2`](https://github.com/discopy/discopy/releases/tag/1.2.2).
   rather than returning `self`, so
   `Tensor([1, 0, 0, 1], Dim(2), Dim(2)).then(None)` raised `TypeError`
   ([#760](https://github.com/discopy/discopy/issues/760)).
-  Six of them take `utils.unbiased`, which already spells the signature;
-  the two `python.finset` ones are written out instead, because the
-  wrapper costs more than the call it wraps there -- composing two finite
-  functions is cheap enough that the extra frame was 29% of it.
+  Five of them take `utils.unbiased`, which already spells the signature.
+  The three in `discopy.python` are written out instead:
+  `python.function.Function` because folding it nests one closure per
+  composition, and the two `python.finset` ones because the wrapper costs
+  more than the call it wraps there -- composing two finite functions is
+  cheap enough that the extra frame was 29% of it.
   `utils.MappingOrCallable.then` is binary too and stays that way:
   it post-composes a mapping with a functor rather than composing two
   morphisms, and `MappingOrCallable` is not an `abc.Category`.

--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -920,6 +920,7 @@ class Functor(Category):
         """
         return cls(lambda x: x, lambda f: f, dom=dom, cod=dom)
 
+    @unbiased
     def then(self, other: Functor) -> Functor:
         """
         The composition of functor with another.
@@ -1085,6 +1086,7 @@ class Transformation(Category):
         """
         return cls(lambda x: dom.cod.id(dom(x)), dom, dom)
 
+    @unbiased
     def then(self, other: Transformation) -> Transformation:
         """
         The vertical composition of a transformation with another.

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -77,6 +77,7 @@ from discopy.utils import (
     get_origin,
     MappingOrCallable,
     RichDisplay,
+    unbiased,
 )
 
 if TYPE_CHECKING:
@@ -1615,7 +1616,9 @@ class Functor(cat.Functor):
     def id(cls, dom=None):
         return cls(lambda x: x, lambda f: f, dom=dom, cod=dom)
 
+    @unbiased
     def then(self, other):
+        """ The composition of a functor with another. """
         assert_isinstance(other, Functor)
         assert_iscomposable(self, other)
         return type(self)(

--- a/discopy/monoidal.py
+++ b/discopy/monoidal.py
@@ -1618,7 +1618,6 @@ class Functor(cat.Functor):
 
     @unbiased
     def then(self, other):
-        """ The composition of a functor with another. """
         assert_isinstance(other, Functor)
         assert_iscomposable(self, other)
         return type(self)(

--- a/discopy/python/finset.py
+++ b/discopy/python/finset.py
@@ -17,7 +17,7 @@ Summary
 """
 
 from __future__ import annotations
-from discopy.utils import assert_isinstance
+from discopy.utils import assert_isinstance, unbiased
 from typing import Iterable, Self, Any
 from collections.abc import Sequence
 
@@ -76,7 +76,9 @@ class Function(MonoidalCategory, Sequence):
     def id(x: int | Nat = 0):
         return Function(list(range(x)), x, x)
 
+    @unbiased
     def then(self, other: Function) -> Function:
+        """ The composite ``self ; other``, read off backwards. """
         inside = [self[other[i]] for i in range(len(other))]
         return Function(inside, self.dom, other.cod)
 
@@ -240,6 +242,7 @@ class Permutation(Function, PROP):
             i = self[i]
         return tuple(cycle)
 
+    @unbiased
     def then(self, other: Self) -> Self:
         """ Return ``self ; other``, i.e. ``result[i] == other[self[i]]``. """
         other = type(self)(other, len(self))

--- a/discopy/python/finset.py
+++ b/discopy/python/finset.py
@@ -17,7 +17,7 @@ Summary
 """
 
 from __future__ import annotations
-from discopy.utils import assert_isinstance, unbiased
+from discopy.utils import assert_isinstance
 from typing import Iterable, Self, Any
 from collections.abc import Sequence
 
@@ -76,11 +76,19 @@ class Function(MonoidalCategory, Sequence):
     def id(x: int | Nat = 0):
         return Function(list(range(x)), x, x)
 
-    @unbiased
-    def then(self, other: Function) -> Function:
-        """ The composite ``self ; other``, read off backwards. """
-        inside = [self[other[i]] for i in range(len(other))]
-        return Function(inside, self.dom, other.cod)
+    def then(self, *others: Function) -> Function:
+        """
+        The composite ``self ; others``, read off backwards, i.e. each
+        index of the last codomain walked back through every function.
+        """
+        if not others:
+            return self
+        factors = (self, ) + others
+        inside = factors[-1].inside
+        for factor in reversed(factors[:-1]):
+            image = factor.inside
+            inside = [image[i] for i in inside]
+        return Function(inside, self.dom, factors[-1].cod)
 
     def tensor(self, other: Function) -> Function:
         inside = list(self.inside) + [
@@ -242,12 +250,16 @@ class Permutation(Function, PROP):
             i = self[i]
         return tuple(cycle)
 
-    @unbiased
-    def then(self, other: Self) -> Self:
-        """ Return ``self ; other``, i.e. ``result[i] == other[self[i]]``. """
-        other = type(self)(other, len(self))
-        elems = (other[self[i]] for i in range(len(self)))
-        return type(self)(elems, len(self))
+    def then(self, *others: Self) -> Self:
+        """ Return ``self ; others``, i.e. each index pushed through them
+        in turn, ``result[i] == other[self[i]]`` for a single ``other``. """
+        if not others:
+            return self
+        inside = self.inside
+        for other in others:
+            image = type(self)(other, len(self)).inside
+            inside = [image[i] for i in inside]
+        return type(self)(inside, len(self))
 
     def dagger(self) -> Self:
         """ Return the inverse permutation. """

--- a/discopy/python/function.py
+++ b/discopy/python/function.py
@@ -84,11 +84,12 @@ class Function(Category):
         for factor, other in zip(factors, others):
             assert_isinstance(other, type(self))
             assert_iscomposable(factor, other)
+        *before, last = factors
 
         def inside(*args):
-            for factor in factors[:-1]:
+            for factor in before:
                 args = tuplify(factor(*args))
-            return factors[-1](*args)
+            return last(*args)
         return type(self)(inside, self.dom, others[-1].cod)
 
     @classproperty

--- a/discopy/python/function.py
+++ b/discopy/python/function.py
@@ -64,17 +64,32 @@ class Function(Category):
         """
         return cls(lambda *xs: untuplify(xs), tuplify(dom), tuplify(dom))
 
-    def then(self, other: Function) -> Function:
+    def then(self, *others: Function) -> Function:
         """
-        The sequential composition of two functions, called with :code:`>>`.
+        The sequential composition of ``n`` functions, called with
+        :code:`>>`.
 
         Parameters:
-            other : The other function to compose in sequence.
+            others : The other functions to compose in sequence.
+
+        Example
+        -------
+        >>> from discopy.python.multiplicative import Function
+        >>> succ = Function(lambda x: x + 1, (int, ), (int, ))
+        >>> assert succ.then(succ, succ)(0) == 3
         """
-        assert_isinstance(other, type(self))
-        assert_iscomposable(self, other)
-        return type(self)(
-            lambda *args: other(*tuplify(self(*args))), self.dom, other.cod)
+        if not others:
+            return self
+        factors = (self, ) + others
+        for factor, other in zip(factors, others):
+            assert_isinstance(other, type(self))
+            assert_iscomposable(factor, other)
+
+        def inside(*args):
+            for factor in factors[:-1]:
+                args = tuplify(factor(*args))
+            return factors[-1](*args)
+        return type(self)(inside, self.dom, others[-1].cod)
 
     @classproperty
     @contextmanager

--- a/discopy/quantum/channel.py
+++ b/discopy/quantum/channel.py
@@ -51,7 +51,7 @@ from discopy.quantum.circuit import (
     Digit, Qudit)
 from discopy.quantum.gates import Discard, Measure, MixedState, Encode, Scalar
 from discopy.tensor import Dim, Tensor
-from discopy.utils import assert_isinstance
+from discopy.utils import assert_isinstance, unbiased
 
 
 class CQ:

--- a/discopy/quantum/channel.py
+++ b/discopy/quantum/channel.py
@@ -174,9 +174,9 @@ class Channel(Tensor):
         assert_isinstance(dom, CQ)
         return cls(Tensor[cls.dtype].id(dom.to_dim()).array, dom, dom)
 
-    def then(self, other: Channel = None, *others: Channel) -> Channel:
-        if other is None or others:
-            return super().then(other, *others)
+    @unbiased
+    def then(self, other: Channel) -> Channel:
+        """ The composition of two channels, as underlying tensors. """
         assert_isinstance(other, type(self))
         array = (self.to_tensor() >> other.to_tensor()).array
         return type(self)(array, self.dom, other.cod)

--- a/discopy/quantum/channel.py
+++ b/discopy/quantum/channel.py
@@ -176,7 +176,6 @@ class Channel(Tensor):
 
     @unbiased
     def then(self, other: Channel) -> Channel:
-        """ The composition of two channels, as underlying tensors. """
         assert_isinstance(other, type(self))
         array = (self.to_tensor() >> other.to_tensor()).array
         return type(self)(array, self.dom, other.cod)

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -56,7 +56,7 @@ from discopy.matrix import (  # noqa: F401
 from discopy.abc import NamedGeneric
 from discopy.python import finset
 from discopy.utils import (
-    factory_name, assert_isinstance, product, assert_isatomic)
+    factory_name, assert_isinstance, product, assert_isatomic, unbiased)
 
 if TYPE_CHECKING:
     import sympy
@@ -137,9 +137,12 @@ class Tensor(Matrix):
     def id(cls, dom=Dim(1)) -> Tensor:
         return cls(Matrix.id(product(dom.inside)).array, dom, dom)
 
-    def then(self, other: Tensor = None, *others: Tensor) -> Tensor:
-        if other is None or others:
-            return super().then(other, *others)
+    @unbiased
+    def then(self, other: Tensor) -> Tensor:
+        """
+        The composition of two tensors, i.e. their contraction over the
+        ``len(self.cod)`` axes they share.
+        """
         assert_isinstance(other, type(self))
         assert_iscomposable(self, other)
         with backend() as np:

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -139,10 +139,6 @@ class Tensor(Matrix):
 
     @unbiased
     def then(self, other: Tensor) -> Tensor:
-        """
-        The composition of two tensors, i.e. their contraction over the
-        ``len(self.cod)`` axes they share.
-        """
         assert_isinstance(other, type(self))
         assert_iscomposable(self, other)
         with backend() as np:


### PR DESCRIPTION
## Why

Closes #760, the sibling of #761 for sequential composition. Quoting the
prompts for this pull request verbatim:

> make another branch for the equivalent issue with `then`. don't open a
> PR yet I want to review first.

> did it impact the benchmarking?

> re-cut it from main instead of stacking and open a new PR, again with
> the proptest label

## What

`abc.Category.then` declares `def then(self, *others: C1) -> C1` and
`cat.Arrow` implements it. Eight classes kept one of the two
non-conforming shapes that #761 is fixing for `tensor`:

`(self, other=None, *others)`: `tensor.Tensor`, `quantum.channel.Channel`.

Plain binary `(self, other)` with no `utils.unbiased`, so a third
argument raised `TypeError`: `cat.Functor`, `cat.Transformation`,
`monoidal.Functor`, `python.function.Function`, `python.finset.Function`,
`python.finset.Permutation`.

Two things fall out, both verified rather than assumed:

- The `None` branch was **dead**, not a unit. Unlike `tensor`, where
  `f.tensor(None) == f`, it forwarded to `cat.Arrow.then` as
  `super().then(None)`, which composes against `None`:
  `Tensor([1, 0, 0, 1], Dim(2), Dim(2)).then(None)` raised `TypeError`.
  It is deleted rather than preserved.
- `python.function.Function.then` nested one closure per composition, so a
  long chain could not be called at all — `f.then(f)` two thousand times,
  then calling the result, raised `RecursionError`. That is a bug fix, and
  the reason this one is taken `n`-ary rather than folded.

`utils.MappingOrCallable.then` is binary too and stays that way: it
post-composes a mapping with a functor rather than composing two
morphisms, and `MappingOrCallable` is not an `abc.Category`, so the
contract does not bind it.

## How

Five take `utils.unbiased`, which already spells `(self, *others)`:
`tensor.Tensor`, `quantum.channel.Channel`, `cat.Functor`,
`cat.Transformation` and `monoidal.Functor`. That is safe here in a way it
was not for `symmetric.Permutation.tensor` in #761: every one of these
bodies returns `type(self)`, so the fold can re-enter them, where that one
returned a plain `Diagram` with no `.perm`.

The three in `discopy.python` are written out instead.
`python.function.Function` because folding it nests one closure per
composition, which is the `RecursionError` above. The two
`python.finset` ones because measuring showed `unbiased` is not free where
the call it wraps is cheap: its extra frame cost **29%** of
`finset.Function.then`, and about 10% of turning a symmetric permutation
into a hypergraph, which composes finite functions throughout. Written out
they are *faster* than the binary methods they replace, not merely even
with them — `Permutation.then` reads both operands off their `inside`
lists once per element, where it used to index `self` and `other` through
`__getitem__` (twice per element) and iterate `self` through the
`Sequence` protocol, which resolves through `__getitem__` again:

| | base | head |
| --- | ---: | ---: |
| `finset.Permutation.then` | 7.6 µs | **5.6 µs** |
| `Permutation.conjugate` (composes twice) | 23.2 µs | **19.5 µs** |
| `finset.Function.then` | 0.98 µs | 0.94 µs |
| symmetric permutation → hypergraph | 681 µs | 667 µs |

In `python.function.Function.then` the last factor is applied without the
`tuplify`/`untuplify` round trip the others go through, since
`untuplify(tuplify(x))` is not `x` for a one-tuple, and the list of
factors is split once when the composite is built rather than on every
call of it. A chain built with `>>` still nests, that operator being
binary.

### On the benchmark suite

Its `k-fold series` cases compose `Diagram`, `Hypergraph` and `CMap`,
none of which this touches, and the job agrees: **PASS**, no regressions
and no speedups among 123 measurements.

Run locally, base against head on one machine, it reported two regressions
over 25% — but a **different two on each run**, and the same commit
compared against *itself* reports one at +25.8%. At this threshold the
suite's noise floor there is one or two cases, so those findings were not
evidence of anything. The numbers above are from 20 000-iteration
micro-benchmarks instead. Chasing the question was still worth it: it is
what found the per-call slice and the `unbiased` overhead, both of which
are fixed here.

The `proptest` label is on this pull request because `cat.Arrow` is the
one category the matrix enrols, and its `associativity` and `unitality`
axioms are laws about `then`.

`pflake8 discopy` clean; `coverage run -m pytest` with `--group all`
synced gives 936 passed and 2 skipped; `pytest proptest/` 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx6uSFsQAKANhJLV1mQVpM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Python functions, finite-set functions, and permutations can now compose multiple operations in a single call.
  - Composition supports complete sequential chains while preserving compatible input and output types.
  - Composition with no additional operations returns the original object where supported.

- **Bug Fixes**
  - Fixed failures when composing more than two functions or transformations.
  - Prevented recursion errors during large function-composition chains.
  - Standardized multi-operation composition behavior across supported structures.

- **Performance**
  - Improved efficiency for finite-set function and permutation composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->